### PR TITLE
feat: Implement Default Prompt Template and Data Storage Options

### DIFF
--- a/options.html
+++ b/options.html
@@ -36,6 +36,13 @@
                     <br><strong>Note:</strong> Gemini does not currently support pasting images. For the best experience, please select AI Studio.
                 </p>
             </div>
+            <div class="form-group">
+                <label for="defaultPromptTemplate">Default Prompt Template (Use {content} as placeholder for Reddit content):</label>
+                <textarea id="defaultPromptTemplate" name="defaultPromptTemplate" rows="4"></textarea>
+                <p class="description">
+                    The {content} placeholder will be replaced with the scraped Reddit content when sending to the AI.
+                </p>
+            </div>
         </div>
 
         <div class="settings-section" id="notificationSettings">
@@ -47,11 +54,27 @@
             </div>
         </div>
 
-        <!-- Placeholder for Advanced Settings -->
-        <!-- <div class="settings-section" id="advancedSettings">
+        <div class="settings-section" id="advancedSettings">
             <h2>Advanced Settings</h2>
-            <p class="description">Future advanced settings will appear here.</p>
-        </div> -->
+            <div class="form-group">
+                <label>Data Storage:</label>
+                <div>
+                    <input type="radio" id="dataStorageDontSave" name="dataStorage" value="dontSave">
+                    <label for="dataStorageDontSave">Don't save scraped content</label>
+                </div>
+                <div>
+                    <input type="radio" id="dataStorageSessionOnly" name="dataStorage" value="sessionOnly">
+                    <label for="dataStorageSessionOnly">Save for current session only</label>
+                </div>
+                <div>
+                    <input type="radio" id="dataStoragePersistent" name="dataStorage" value="persistent" checked>
+                    <label for="dataStoragePersistent">Save persistently (local storage)</label>
+                </div>
+                <p class="description">
+                    Choose how scraped content is stored. "Don't save" discards content after sending. "Session only" keeps it until the browser closes. "Persistent" saves it in local storage for future sessions.
+                </p>
+            </div>
+        </div>
 
         <div class="save-actions">
             <!-- The save button from RedditAIUI is explicit. Here, saving is implicit on change. -->


### PR DESCRIPTION
This commit introduces several new features and enhancements to the extension:

1.  **Default Prompt Template:**
    *   You can now define a custom prompt template in the extension options (options.html, options.js).
    *   The template uses `{content}` as a placeholder for the scraped Reddit data.
    *   I apply this template before sending data to the selected AI platform.
    *   If no template is set, or if `{content}` is missing, it falls back to sensible defaults.

2.  **Advanced Settings Section:**
    *   A new "Advanced Settings" section has been added to `options.html` for better organization of technical settings.

3.  **Data Storage Options:**
    *   You can now choose how scraped Reddit content is stored (options.html, options.js):
        *   **"Don't save scraped content":** Data is held in memory by me and passed directly to the AI without being written to `chrome.storage`.
        *   **"Save for current session only":** Data is stored in `chrome.storage.session` and is cleared when the browser closes.
        *   **"Save persistently (local storage)":** This is the previous default behavior, using `chrome.storage.local`.
    *   I now handle data according to the selected option.
    *   Data is cleared from the respective storage area after successful pasting or if scraping is stopped.

4.  **Refined Data Flow:**
    *   I now consistently pass the final text content (with template applied, if any) and any media URLs directly to `aiPaster.js` via a message.
    *   `aiPaster.js` has been updated to use this directly passed data, removing the need for it to fetch from `chrome.storage.local` and simplifying its logic.

These changes provide you with more flexibility and control over how the extension handles prompts and data storage. All related UI elements and logic have been updated.