### PR TITLE
Hotfix: I've corrected a SyntaxError in service_worker.js.

### DIFF
--- a/service_worker.js
+++ b/service_worker.js
@@ -39,7 +39,8 @@ function broadcastScrapingState() {
             if (chrome.runtime.lastError) {
                 // console.warn('Floating panel update error (normal if panel not ready/tab closed):', scrapingState.lastScrapedTabId, chrome.runtime.lastError.message);
             }
-        }).catch(e => { /* console.warn('Catch: Floating panel update error:', e.message) */ });
+            // Removed .catch(e => { /* console.warn('Catch: Floating panel update error:', e.message) */ });
+        });
     }
 }
 


### PR DESCRIPTION
- I removed an incorrectly chained .catch() from a chrome.tabs.sendMessage call within the broadcastScrapingState function.
- This call used a callback, so chaining .catch() was invalid and likely caused the reported 'missing ) after argument list' syntax error, preventing service worker registration.