### PR TITLE
I made a modification to `service_worker.js` to log the exact `apiUrl…

### DIFF
--- a/service_worker.js
+++ b/service_worker.js
@@ -207,6 +207,8 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
                         // ... (original API URL, headers, body setup based on provider) ...
                         if (provider === 'openai') { /* ... */ } else if (provider === 'gemini') { /* ... */ } else { /* error handling */ return; }
 
+                        console.log(`Service Worker (Step 6 Modified): Using effective model name: ${effectiveModelName} for provider: ${provider}`); // Ensure this log is also updated if it wasn't
+                        console.log(`Service Worker (Step 6 Modified): Fetching API. URL: ${apiUrl}`, `Body: ${body}`); // Log URL and body
                         try { // THIS IS THE TRY BLOCK NEAR ORIGINAL ERROR LINE 647
                             scrapingState.message = `Sending request to ${provider} API...`;
                             scrapingState.percentage = 85; broadcastScrapingState();


### PR DESCRIPTION
…` and `body` string before the `fetch` request. This will help diagnose an issue where the Gemini API call was returning unexpected code, which suggests a problem with the request URL or how it's being resolved. Other logging for raw non-JSON responses is still in place.