### PR TITLE
Audit pass: fix broken subsystems, add direct API mode and a Firefox build (v1.4.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ yarn-error.log
 dist/
 build/
 dist-extension/
+dist-extension-firefox/
 
 # ===================
 # Temporary Files

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🚀 Reddit to AI - Chrome Extension
 
-[![Version](https://img.shields.io/badge/version-1.2.1-blue.svg?style=for-the-badge)](manifest.json)
+[![Manifest V3](https://img.shields.io/badge/manifest-v3-blue.svg?style=for-the-badge)](src/manifest.json)
 [![License](https://img.shields.io/badge/license-MPL--2.0-green.svg?style=for-the-badge)](LICENSE)
 [![Contributions Welcome](https://img.shields.io/badge/contributions-welcome-orange.svg?style=for-the-badge)](#contributing)
 
@@ -28,7 +28,7 @@
 
 ## Overview
 
-**Reddit to AI** is a powerful Chrome extension that bridges the gap between Reddit discussions and Large Language Models (LLMs). It allows you to scrape comprehensive data from any Reddit thread—including the main post, nested comments, and images—and seamlessly transfer it to an AI chat interface (like ChatGPT or Gemini) with a pre-configured prompt.
+**Reddit to AI** is a powerful browser extension (Chrome and Firefox) that bridges the gap between Reddit discussions and Large Language Models (LLMs). It allows you to scrape comprehensive data from any Reddit thread—including the main post, nested comments, and images—and seamlessly transfer it to an AI chat interface (like ChatGPT or Gemini) with a pre-configured prompt.
 
 Whether you're a researcher analyzing sentiment, a user looking for a "TL;DR", or just someone who wants to understand a complex debate, this tool automates the tedious copy-pasting and formatting process.
 
@@ -74,6 +74,10 @@ The extension currently supports automatic pasting and prompt injection for:
 *   **OpenAI ChatGPT** (chatgpt.com)
 *   **Anthropic Claude** (claude.ai)
 *   **Google AI Studio** (aistudio.google.com)
+*   **DeepSeek** (chat.deepseek.com)
+*   **Groq** (groq.com)
+
+You can also point the extension at your own chat UI by adding a **custom origin** in Options; without a configured origin the custom provider reports an error instead of opening a default page.
 
 ---
 
@@ -88,14 +92,41 @@ The extension currently supports automatic pasting and prompt injection for:
     *   Enable **Developer mode** (top right toggle).
 3.  **Load Unpacked**:
     *   Click **Load unpacked**.
-    *   Select the folder where you cloned the repository.
+    *   Select the `src/` folder inside the cloned repository (that is where `manifest.json` lives).
 4.  **Pin it**: Pin the "Reddit to AI" icon to your toolbar for easy access!
+
+### 🦊 Firefox
+
+Firefox needs a slightly different `manifest.json` (an MV3 event page instead of a
+service worker, plus a Gecko add-on ID). It is generated for you by the packaging
+step rather than checked in, so the two manifests cannot drift apart.
+
+1.  **Build the Firefox payload**:
+    ```bash
+    npm install
+    npm run package:extension
+    ```
+    This writes `dist-extension-firefox/` (an unpacked build) and
+    `Reddit-to-AI-v<version>-firefox.zip` (the AMO upload archive) alongside the
+    Chrome artifacts.
+2.  **Load it temporarily**:
+    *   Navigate to `about:debugging#/runtime/this-firefox`.
+    *   Click **Load Temporary Add-on…** and pick
+        `dist-extension-firefox/manifest.json`.
+    *   Temporary add-ons are removed when Firefox restarts. For a persistent
+        install, the zip has to be signed through
+        [addons.mozilla.org](https://addons.mozilla.org).
+3.  **Grant site access**: Firefox treats MV3 host permissions as optional. Open
+    **Add-ons → Reddit to AI → Permissions** and allow access to Reddit and your AI
+    sites if scraping or auto-paste does nothing.
+
+Firefox 121 or newer is required (`strict_min_version` in the generated manifest).
 
 ---
 
 ## 🧰 Software Requirements
 
-*   **Browser**: Google Chrome (or Chromium-compatible browser) with Manifest V3 support.
+*   **Browser**: Google Chrome (or Chromium-compatible browser) with Manifest V3 support, or Firefox 121+.
 *   **Runtime**: No backend server required; all extension logic runs locally.
 *   **Development checks**: See [SOFTWARE_REQUIREMENTS.md](SOFTWARE_REQUIREMENTS.md) for a full environment and tooling checklist.
 
@@ -105,6 +136,7 @@ The extension currently supports automatic pasting and prompt injection for:
 
 1.  **Navigate to Reddit**: Open any Reddit thread you want to analyze.
 2.  **Open Extension**: Click the **Reddit to AI** icon.
+    *   Shortcuts: press **Alt+Shift+S** to scrape the active thread, or right-click a thread page (or a thread link anywhere) and choose **Scrape this thread with Reddit to AI**. Rebind the shortcut at `chrome://extensions/shortcuts`.
 3.  **Configure (Optional)**:
     *   Use **Quick Filters** in the popup to hide bots or set a minimum score.
     *   Choose your destination platform (e.g., Gemini, ChatGPT).
@@ -139,7 +171,7 @@ Right-click the extension icon and select **Options** to access advanced setting
 
 *   **No training pipeline**: This repository does not train or evaluate machine-learning models.
 *   **No dataset artifacts**: This project scrapes public Reddit thread data at runtime and does not ship training/testing datasets.
-*   **Model links**: External AI platforms (Gemini, ChatGPT, Claude, AI Studio) are destinations for pasted prompts, not bundled models.
+*   **Model links**: External AI platforms (Gemini, ChatGPT, Claude, AI Studio, DeepSeek, Groq) are destinations for pasted prompts, not bundled models.
 
 ---
 
@@ -162,6 +194,9 @@ Reddit to AI is ready for the world! The interface is fully localized for:
 *   **Context Window Limits**: Extremely large threads can still exceed some AI model input limits. Use the preview meter, context presets, trim logic, or score filters to reduce prompt size.
 *   **DOM Changes**: Reddit and AI chat sites frequently update their UI. If scraping or auto-paste stops working, selectors may need updating.
 *   **Browser Security**: Some browsers may block automatic paste. The fallback overlay lets you copy the prompt manually.
+*   **Firefox host permissions**: Firefox MV3 makes `host_permissions` opt-in. Until you grant them under **Add-ons → Reddit to AI → Permissions**, scraping and auto-paste stay silent.
+*   **Firefox keyboard shortcut**: `Alt+Shift+S` is declared for both browsers, but Firefox may drop the binding if another add-on already claims it. Rebind it under **Add-ons → gear icon → Manage Extension Shortcuts**.
+*   **Firefox options page**: Firefox opens the settings page via `options_ui` in a full tab; the layout is identical to Chrome's.
 
 ---
 
@@ -183,7 +218,10 @@ This project is licensed under the **Mozilla Public License 2.0 (MPL-2.0)**. See
 
 ## 🧹 Maintenance Notes
 
-*   Version metadata now matches `manifest.json` / `package.json` at **1.2.1**.
-*   `__MACOSX` archive artifacts are ignored/removed from the packaged repo.
-*   The unused `marked.min.js` file was removed.
-*   User-facing status text now says content/prompt sending instead of summary sending.
+*   Extension sources live in `src/`; repo tooling (`scripts/`, `tests/`) stays outside the packaged payload.
+*   `src/manifest.json` and `package.json` versions are asserted to match by `npm run check`; the release ZIPs are named from that version.
+*   `src/manifest.json` is the Chrome manifest and the single source of truth. The Firefox manifest is derived from it at package time by the pure transform in `scripts/firefox-manifest.mjs` (event-page `background.scripts`, `browser_specific_settings.gecko`, `options_ui` instead of `options_page`, no `use_dynamic_url`) and checked by `tests/firefoxManifest.test.mjs` plus `scripts/validate-release.mjs`.
+*   The `importScripts(...)` call at the top of `src/service_worker.js` is guarded by a `typeof importScripts === 'function'` check: Chrome uses it, Firefox loads the same four libraries through `background.scripts` instead. Keep the two lists in the same order - a test asserts it.
+*   `npm run check` runs JSON validation, ESLint, the test suite, packaging, and release validation. Tests are discovered automatically via `node --test`, so a new `tests/*.test.mjs` file needs no script change.
+*   Permissions are allowlisted in both `tests/releaseManifest.test.mjs` and `scripts/validate-release.mjs`; the broad `tabs` permission is deliberately not requested.
+*   Historical per-release notes for v1.2.1 are archived in `UPDATE_NOTES.md`.

--- a/UPDATE_NOTES.md
+++ b/UPDATE_NOTES.md
@@ -1,6 +1,8 @@
 # Reddit to AI v1.2.1 Update Notes
 
-This update expands Reddit to AI from a direct scrape-and-send extension into a preview-first workflow with stronger controls for context size, scraping reliability, privacy, and history management.
+> Historical release notes for v1.2.1. The current release is tracked in `src/manifest.json` and `package.json`; this file is not updated for later versions.
+
+This update expanded Reddit to AI from a direct scrape-and-send extension into a preview-first workflow with stronger controls for context size, scraping reliability, privacy, and history management.
 
 ## Added
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,14 +6,14 @@ export default [
     ignores: [
       "node_modules/**",
       "dist-extension/**",
-      "marked.min.js",
-      "_locales/**",
-      "images/**"
+      "dist-extension-firefox/**",
+      "src/_locales/**",
+      "src/images/**"
     ]
   },
   {
     ...js.configs.recommended,
-    files: ["*.js"],
+    files: ["src/**/*.js"],
     languageOptions: {
       ecmaVersion: 2022,
       sourceType: "script",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reddit-to-ai",
-  "version": "1.2.2",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reddit-to-ai",
-      "version": "1.2.2",
+      "version": "1.3.1",
       "devDependencies": {
         "@eslint/js": "^9.25.1",
         "eslint": "^9.25.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reddit-to-ai",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reddit-to-ai",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "devDependencies": {
         "@eslint/js": "^9.25.1",
         "eslint": "^9.25.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reddit-to-ai",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "private": true,
   "description": "Repository tooling for the Reddit to AI Chrome extension.",
   "type": "module",
@@ -8,7 +8,7 @@
     "lint": "eslint .",
     "validate:json": "node scripts/validate-json.mjs",
     "validate:release": "node scripts/validate-release.mjs",
-    "test": "node tests/promptBuilder.test.mjs && node tests/redditFixture.test.mjs && node tests/aiPasterImagePaste.test.mjs && node tests/backgroundScraperReplies.test.mjs && node tests/previewSendFlow.test.mjs && node tests/popupBatchMode.test.mjs && node tests/optionsHistoryStatus.test.mjs && node tests/releaseManifest.test.mjs && node tests/i18nMessages.test.mjs && node tests/noRemoteAssets.test.mjs && node tests/packageExtension.test.mjs && node tests/domFallback.test.mjs && node tests/backgroundSelectorSync.test.mjs && node tests/aiPasterSelectorMerge.test.mjs && node tests/interactiveCommentPruning.test.mjs && node tests/serviceWorkerCustomOrigins.test.mjs && node tests/bpeTokenizer.test.mjs && node tests/subredditTemplates.test.mjs && node tests/exportOptions.test.mjs && node tests/backgroundBatchResumption.test.mjs && node tests/tooltip.test.mjs && node tests/popupBudgetBar.test.mjs && node tests/subredditRouteTester.test.mjs",
+    "test": "node --test \"tests/**/*.test.mjs\"",
     "package:extension": "node scripts/package-extension.mjs",
     "check": "npm run validate:json && npm run lint && npm test && npm run package:extension && npm run validate:release"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reddit-to-ai",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "private": true,
   "description": "Repository tooling for the Reddit to AI Chrome extension.",
   "type": "module",

--- a/scripts/firefox-manifest.mjs
+++ b/scripts/firefox-manifest.mjs
@@ -1,0 +1,65 @@
+// Firefox ships the exact same sources as Chrome; only the manifest differs. Rather
+// than maintaining two manifests by hand (and letting them drift), the Firefox
+// manifest is derived from src/manifest.json at package time by this pure transform.
+//
+// Differences Firefox requires:
+//   1. `background.service_worker` -> `background.scripts`. Firefox MV3 uses an event
+//      page, not a service worker. `importScripts` is unavailable there, so the four
+//      libraries the worker imports are listed ahead of service_worker.js and loaded
+//      as classic scripts sharing one global scope - identical to what importScripts
+//      produces in Chrome. The importScripts call in service_worker.js is guarded by
+//      a `typeof importScripts === 'function'` check for exactly this reason.
+//   2. `browser_specific_settings.gecko.id` is mandatory for signing/installing.
+//   3. `options_page` is Chrome-only. Firefox reads `options_ui`; without it,
+//      chrome.runtime.openOptionsPage() has nothing to open.
+//   4. `use_dynamic_url` inside web_accessible_resources is a Chrome-only key and is
+//      dropped rather than left for Firefox's manifest linter to complain about.
+
+export const GECKO_ID = 'reddit-to-ai@alpyalay';
+// 121 is comfortably past every API this extension touches: MV3 background.scripts
+// event pages (109+), storage.session (115+), scripting.registerContentScripts (102+).
+export const GECKO_MIN_VERSION = '121.0';
+
+// Must match the importScripts(...) argument order at the top of service_worker.js.
+export const BACKGROUND_LIBS = [
+  'cl100k_base.js',
+  'redditParser.js',
+  'promptBuilder.js',
+  'apiProviders.js'
+];
+
+export function toFirefoxManifest(chromeManifest) {
+  const manifest = structuredClone(chromeManifest);
+
+  const workerFile = chromeManifest.background?.service_worker;
+  if (!workerFile) {
+    throw new Error('Chrome manifest is missing background.service_worker');
+  }
+  manifest.background = { scripts: [...BACKGROUND_LIBS, workerFile] };
+
+  manifest.browser_specific_settings = {
+    ...(manifest.browser_specific_settings || {}),
+    gecko: {
+      id: GECKO_ID,
+      strict_min_version: GECKO_MIN_VERSION
+    }
+  };
+
+  if (manifest.options_page) {
+    manifest.options_ui = {
+      page: manifest.options_page,
+      open_in_tab: true
+    };
+    delete manifest.options_page;
+  }
+
+  if (Array.isArray(manifest.web_accessible_resources)) {
+    manifest.web_accessible_resources = manifest.web_accessible_resources.map(entry => {
+      if (!entry || typeof entry !== 'object') return entry;
+      const { use_dynamic_url: _dropped, ...rest } = entry;
+      return rest;
+    });
+  }
+
+  return manifest;
+}

--- a/scripts/package-extension.mjs
+++ b/scripts/package-extension.mjs
@@ -2,9 +2,11 @@ import JSZip from 'jszip';
 import { cp, mkdir, readdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
 import { dirname, join, relative, sep } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import { toFirefoxManifest } from './firefox-manifest.mjs';
 
 export const root = dirname(fileURLToPath(new URL('../package.json', import.meta.url)));
 export const outDir = join(root, 'dist-extension');
+export const firefoxOutDir = join(root, 'dist-extension-firefox');
 
 export const excludedDirs = new Set([
   '.git',
@@ -15,6 +17,7 @@ export const excludedDirs = new Set([
   'tests',
   'scripts',
   'dist-extension',
+  'dist-extension-firefox',
   '__MACOSX',
   'docs'
 ]);
@@ -115,6 +118,20 @@ export async function verifyZip(stageDir = outDir, zipPath) {
   return actualFiles;
 }
 
+// The Firefox payload is byte-identical to the Chrome one except for manifest.json,
+// which is regenerated from the Chrome manifest by the transform in
+// scripts/firefox-manifest.mjs.
+export async function stageFirefox(stageDir = firefoxOutDir) {
+  await rm(stageDir, { recursive: true, force: true });
+  await mkdir(stageDir, { recursive: true });
+  await copyTree(join(root, 'src'), stageDir);
+
+  const chromeManifest = JSON.parse(await readFile(join(root, 'src', 'manifest.json'), 'utf8'));
+  const firefoxManifest = toFirefoxManifest(chromeManifest);
+  await writeFile(join(stageDir, 'manifest.json'), `${JSON.stringify(firefoxManifest, null, 2)}\n`, 'utf8');
+  return stageDir;
+}
+
 export async function packageExtension() {
   await rm(outDir, { recursive: true, force: true });
   await mkdir(outDir, { recursive: true });
@@ -127,10 +144,20 @@ export async function packageExtension() {
   const files = await createZip(outDir, zipPath);
   await verifyZip(outDir, zipPath);
 
+  await stageFirefox(firefoxOutDir);
+  const firefoxZipName = `Reddit-to-AI-v${version}-firefox.zip`;
+  const firefoxZipPath = join(root, firefoxZipName);
+  await rm(firefoxZipPath, { force: true });
+  const firefoxFiles = await createZip(firefoxOutDir, firefoxZipPath);
+  await verifyZip(firefoxOutDir, firefoxZipPath);
+
   console.log(`Extension package staged at ${outDir}`);
   console.log(`Upload archive created at ${zipPath}`);
   console.log(`Verified ${files.length} files in ${zipName}`);
-  return { outDir, zipPath, files };
+  console.log(`Firefox package staged at ${firefoxOutDir}`);
+  console.log(`Firefox archive created at ${firefoxZipPath}`);
+  console.log(`Verified ${firefoxFiles.length} files in ${firefoxZipName}`);
+  return { outDir, zipPath, files, firefoxOutDir, firefoxZipPath, firefoxFiles };
 }
 
 const isCli = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;

--- a/scripts/validate-json.mjs
+++ b/scripts/validate-json.mjs
@@ -6,7 +6,7 @@ const REQUIRED_FILES = [
   "src/manifest.json",
   "src/_locales/en/messages.json"
 ];
-const IGNORE_DIRS = new Set([".git", "node_modules", "images", "dist-extension", "tests"]);
+const IGNORE_DIRS = new Set([".git", "node_modules", "images", "dist-extension", "dist-extension-firefox", "tests"]);
 
 async function exists(filePath) {
   try {

--- a/scripts/validate-release.mjs
+++ b/scripts/validate-release.mjs
@@ -2,9 +2,11 @@ import JSZip from 'jszip';
 import { readdir, readFile, stat } from 'node:fs/promises';
 import { dirname, join, relative, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { BACKGROUND_LIBS, GECKO_ID } from './firefox-manifest.mjs';
 
 const root = dirname(fileURLToPath(new URL('../package.json', import.meta.url)));
 const stageDir = join(root, 'dist-extension');
+const firefoxStageDir = join(root, 'dist-extension-firefox');
 
 const forbiddenPathParts = new Set([
   '.git',
@@ -15,6 +17,8 @@ const forbiddenPathParts = new Set([
   'tests',
   'scripts',
   'docs',
+  'dist-extension',
+  'dist-extension-firefox',
   '__MACOSX'
 ]);
 
@@ -40,6 +44,7 @@ const requiredFiles = [
   'preview.js',
   'service_worker.js',
   'promptBuilder.js',
+  'apiProviders.js',
   'cl100k_base.js',
   'cl100k_base.json',
   'redditScraper.js',
@@ -95,18 +100,18 @@ function validatePayloadFileList(files) {
   }
 }
 
-async function validateNoRemotePageAssets(files) {
+async function validateNoRemotePageAssets(files, dir = stageDir) {
   const pageAssetFiles = files.filter(file => /\.(html|css)$/i.test(file));
   const remoteAssetPattern = /\b(?:href|src)\s*=\s*["']https?:\/\/|@import\s+url\(["']?https?:\/\//i;
   for (const file of pageAssetFiles) {
-    const text = await readFile(join(stageDir, file), 'utf8');
+    const text = await readFile(join(dir, file), 'utf8');
     assert(!remoteAssetPattern.test(text), `Remote page asset reference found in ${file}`);
     assert(!/fonts\.(?:googleapis|gstatic)\.com/i.test(text), `Remote Google Fonts reference found in ${file}`);
   }
 }
 
-async function validateManifest(files) {
-  const manifest = await readJson(join(stageDir, 'manifest.json'));
+async function validateManifest(files, dir = stageDir) {
+  const manifest = await readJson(join(dir, 'manifest.json'));
   const packageJson = await readJson(join(root, 'package.json'));
   assert(manifest.manifest_version === 3, 'Manifest must be MV3');
   assert(/^\d+\.\d+\.\d+$/.test(manifest.version || ''), `Invalid manifest version: ${manifest.version || '<missing>'}`);
@@ -114,7 +119,7 @@ async function validateManifest(files) {
   assert(manifest.default_locale === 'en', 'Manifest default_locale must be en');
   assert(files.includes(`_locales/${manifest.default_locale}/messages.json`), 'Default locale messages file is missing');
 
-  const allowedPermissions = new Set(['activeTab', 'scripting', 'storage', 'notifications', 'tabs', 'unlimitedStorage']);
+  const allowedPermissions = new Set(['activeTab', 'scripting', 'storage', 'notifications', 'unlimitedStorage', 'contextMenus']);
   for (const permission of manifest.permissions || []) {
     assert(allowedPermissions.has(permission), `Unexpected manifest permission: ${permission}`);
   }
@@ -130,7 +135,10 @@ async function validateManifest(files) {
     'https://claude.ai/*',
     'https://aistudio.google.com/*',
     'https://chat.deepseek.com/*',
-    'https://*.groq.com/*'
+    'https://*.groq.com/*',
+    'https://api.anthropic.com/*',
+    'https://api.openai.com/*',
+    'https://generativelanguage.googleapis.com/*'
   ]);
   for (const host of manifest.host_permissions || []) {
     assert(allowedHostPermissions.has(host), `Unexpected host permission: ${host}`);
@@ -146,8 +154,8 @@ async function validateManifest(files) {
   return manifest;
 }
 
-async function validateZip(files, version) {
-  const zipName = `Reddit-to-AI-v${version}-upload.zip`;
+async function validateZip(files, version, suffix = 'upload') {
+  const zipName = `Reddit-to-AI-v${version}-${suffix}.zip`;
   const zipPath = join(root, zipName);
   const zip = await JSZip.loadAsync(await readFile(zipPath));
   const zipFiles = Object.values(zip.files)
@@ -155,8 +163,30 @@ async function validateZip(files, version) {
     .map(entry => entry.name)
     .sort();
 
-  assert(JSON.stringify(zipFiles) === JSON.stringify(files), `${zipName} contents do not match dist-extension`);
+  assert(JSON.stringify(zipFiles) === JSON.stringify(files), `${zipName} contents do not match its staged payload`);
   return zipName;
+}
+
+// Firefox ships the same payload with a transformed manifest. Everything the Chrome
+// manifest is checked for still applies; these are the Gecko-specific extras.
+function validateFirefoxManifest(manifest, chromeManifest) {
+  assert(!manifest.background?.service_worker, 'Firefox manifest must not declare background.service_worker');
+  assert(Array.isArray(manifest.background?.scripts), 'Firefox manifest must declare background.scripts');
+  assert(
+    JSON.stringify(manifest.background.scripts) === JSON.stringify([...BACKGROUND_LIBS, 'service_worker.js']),
+    'Firefox background.scripts must load the shared libraries before service_worker.js'
+  );
+  assert(manifest.browser_specific_settings?.gecko?.id === GECKO_ID, `Firefox manifest must declare gecko id ${GECKO_ID}`);
+  assert(
+    /^\d+\.\d+$/.test(manifest.browser_specific_settings.gecko.strict_min_version || ''),
+    'Firefox manifest must declare a gecko strict_min_version'
+  );
+  assert(!('options_page' in manifest), 'Firefox manifest must use options_ui instead of options_page');
+  assert(manifest.options_ui?.page === 'options.html', 'Firefox manifest must point options_ui at options.html');
+  for (const entry of manifest.web_accessible_resources || []) {
+    assert(!('use_dynamic_url' in entry), 'use_dynamic_url is Chrome-only and must be stripped for Firefox');
+  }
+  assert(manifest.version === chromeManifest.version, 'Firefox and Chrome manifests must share a version');
 }
 
 const files = await collectFiles(stageDir);
@@ -165,5 +195,14 @@ await validateNoRemotePageAssets(files);
 const manifest = await validateManifest(files);
 const zipName = await validateZip(files, manifest.version);
 
+const firefoxFiles = await collectFiles(firefoxStageDir);
+validatePayloadFileList(firefoxFiles);
+await validateNoRemotePageAssets(firefoxFiles, firefoxStageDir);
+const firefoxManifest = await validateManifest(firefoxFiles, firefoxStageDir);
+validateFirefoxManifest(firefoxManifest, manifest);
+const firefoxZipName = await validateZip(firefoxFiles, firefoxManifest.version, 'firefox');
+
 console.log(`Release payload valid: ${files.length} files staged in dist-extension`);
 console.log(`Upload archive valid: ${zipName}`);
+console.log(`Firefox payload valid: ${firefoxFiles.length} files staged in dist-extension-firefox`);
+console.log(`Firefox archive valid: ${firefoxZipName}`);

--- a/selectors.json
+++ b/selectors.json
@@ -1,0 +1,31 @@
+{
+  "version": 1,
+  "gemini": {
+    "inputSelector": "div.ql-editor[contenteditable=\"true\"], div[contenteditable=\"true\"].ql-editor, div.rich-textarea > div[contenteditable=\"true\"], div[contenteditable=\"true\"]",
+    "isContentEditable": true
+  },
+  "chatgpt": {
+    "inputSelector": "#prompt-textarea, div[contenteditable=\"true\"]#prompt-textarea, textarea",
+    "isContentEditable": true
+  },
+  "claude": {
+    "inputSelector": "div[contenteditable=\"true\"], [contenteditable=\"true\"]",
+    "isContentEditable": true
+  },
+  "aistudio": {
+    "inputSelector": "textarea, div[contenteditable=\"true\"]",
+    "isContentEditable": false
+  },
+  "deepseek": {
+    "inputSelector": "textarea, #chat-input, div[contenteditable=\"true\"]",
+    "isContentEditable": false
+  },
+  "groq": {
+    "inputSelector": "textarea, #chat-input, div[contenteditable=\"true\"]",
+    "isContentEditable": false
+  },
+  "custom": {
+    "inputSelector": "textarea, div[contenteditable=\"true\"]",
+    "isContentEditable": false
+  }
+}

--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -552,5 +552,145 @@
     },
     "error": {
         "message": "Error"
+    },
+    "popup_preset_name_label": {
+        "message": "Voreinstellungsname",
+        "description": "Label for the inline preset-name field in the popup"
+    },
+    "popup_preset_name_placeholder": {
+        "message": "Voreinstellungsname",
+        "description": "Placeholder for the inline preset-name field"
+    },
+    "popup_preset_name_confirm": {
+        "message": "Speichern",
+        "description": "Confirm button for saving a quick prompt as a preset"
+    },
+    "popup_preset_name_cancel": {
+        "message": "Abbrechen",
+        "description": "Cancel button for the inline preset-name field"
+    },
+    "popup_preset_name_default": {
+        "message": "Schnell-Prompt",
+        "description": "Fallback name suggested when saving a quick prompt preset"
+    },
+    "command_scrape_current_thread": {
+        "message": "Aktuellen Reddit-Thread auslesen",
+        "description": "Description for the keyboard shortcut that scrapes the active Reddit thread"
+    },
+    "context_menu_scrape_thread": {
+        "message": "Diesen Thread mit Reddit to AI auslesen",
+        "description": "Right-click menu entry that scrapes a Reddit thread"
+    },
+    "sw_error_custom_origin_missing": {
+        "message": "Es ist kein eigener KI-Ursprung konfiguriert. Füge zuerst einen in den Optionen hinzu.",
+        "description": "Error shown when the custom AI provider is selected without a configured origin"
+    },
+    "preview_api_eyebrow": {
+        "message": "Direkte API"
+    },
+    "preview_api_title": {
+        "message": "Mit eigenem API-Schlüssel senden"
+    },
+    "preview_api_description": {
+        "message": "Sende den Prompt direkt an einen Anbieter und lies die Antwort hier, ohne einen KI-Chat-Tab zu öffnen."
+    },
+    "preview_api_provider_label": {
+        "message": "API-Anbieter"
+    },
+    "preview_api_send": {
+        "message": "Über API senden"
+    },
+    "preview_api_no_key": {
+        "message": "Für diesen Anbieter ist kein API-Schlüssel konfiguriert."
+    },
+    "preview_api_no_key_for": {
+        "message": "Für $1 ist kein API-Schlüssel konfiguriert."
+    },
+    "preview_api_open_options": {
+        "message": "Schlüssel in den Optionen hinzufügen"
+    },
+    "preview_api_loading": {
+        "message": "Warte auf die KI-Antwort…"
+    },
+    "preview_api_retry": {
+        "message": "Erneut versuchen"
+    },
+    "preview_api_retryable": {
+        "message": "Das scheint vorübergehend zu sein – versuche es gleich noch einmal."
+    },
+    "preview_api_copy": {
+        "message": "Antwort kopieren"
+    },
+    "preview_api_copied": {
+        "message": "API-Antwort in die Zwischenablage kopiert."
+    },
+    "preview_api_refused": {
+        "message": "Der Anbieter hat die Beantwortung dieser Anfrage abgelehnt."
+    },
+    "preview_api_empty_response": {
+        "message": "Der Anbieter hat eine leere Antwort zurückgegeben."
+    },
+    "preview_api_empty_prompt": {
+        "message": "Der Prompt ist leer."
+    },
+    "preview_api_truncated": {
+        "message": "am Token-Limit abgeschnitten"
+    },
+    "preview_api_failed": {
+        "message": "Die API-Anfrage ist fehlgeschlagen."
+    },
+    "preview_api_status_sending": {
+        "message": "Sende den Prompt an die API…"
+    },
+    "preview_api_status_done": {
+        "message": "API-Antwort empfangen."
+    },
+    "preview_api_status_failed": {
+        "message": "API-Anfrage fehlgeschlagen."
+    },
+    "options_card_direct_api_title": {
+        "message": "Direkte API"
+    },
+    "options_direct_api_intro": {
+        "message": "Füge deinen eigenen API-Schlüssel hinzu, um Antworten direkt in der Prompt-Vorschau zu erhalten, ohne einen KI-Chat-Tab zu öffnen."
+    },
+    "options_direct_api_warning": {
+        "message": "Schlüssel werden nur lokal auf diesem Gerät gespeichert – sie werden nie mit deinem Google-Konto synchronisiert und nie in einen Einstellungsexport aufgenommen. Anfragen gehen direkt von deinem Browser an den Anbieter, und dieser stellt dir die Kosten in Rechnung."
+    },
+    "options_direct_api_key_label": {
+        "message": "API-Schlüssel"
+    },
+    "options_direct_api_key_placeholder": {
+        "message": "API-Schlüssel einfügen"
+    },
+    "options_direct_api_model_label": {
+        "message": "Modell"
+    },
+    "options_direct_api_model_hint": {
+        "message": "Jede Modell-ID, die dieser Anbieter akzeptiert."
+    },
+    "options_direct_api_show": {
+        "message": "Anzeigen"
+    },
+    "options_direct_api_hide": {
+        "message": "Verbergen"
+    },
+    "options_direct_api_test": {
+        "message": "Schlüssel testen"
+    },
+    "options_direct_api_testing": {
+        "message": "Teste"
+    },
+    "options_direct_api_test_ok": {
+        "message": "Schlüssel funktioniert."
+    },
+    "options_direct_api_test_no_key": {
+        "message": "Gib zuerst einen API-Schlüssel ein."
+    },
+    "options_direct_api_clear": {
+        "message": "Schlüssel entfernen"
+    },
+    "options_direct_api_cleared": {
+        "message": "Schlüssel entfernt."
     }
 }

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -554,5 +554,145 @@
     },
     "error": {
         "message": "Error"
+    },
+    "popup_preset_name_label": {
+        "message": "Preset name",
+        "description": "Label for the inline preset-name field in the popup"
+    },
+    "popup_preset_name_placeholder": {
+        "message": "Preset name",
+        "description": "Placeholder for the inline preset-name field"
+    },
+    "popup_preset_name_confirm": {
+        "message": "Save",
+        "description": "Confirm button for saving a quick prompt as a preset"
+    },
+    "popup_preset_name_cancel": {
+        "message": "Cancel",
+        "description": "Cancel button for the inline preset-name field"
+    },
+    "popup_preset_name_default": {
+        "message": "Quick prompt",
+        "description": "Fallback name suggested when saving a quick prompt preset"
+    },
+    "command_scrape_current_thread": {
+        "message": "Scrape the current Reddit thread",
+        "description": "Description for the keyboard shortcut that scrapes the active Reddit thread"
+    },
+    "context_menu_scrape_thread": {
+        "message": "Scrape this thread with Reddit to AI",
+        "description": "Right-click menu entry that scrapes a Reddit thread"
+    },
+    "sw_error_custom_origin_missing": {
+        "message": "No custom AI origin is configured. Add one in Options before using the custom provider.",
+        "description": "Error shown when the custom AI provider is selected without a configured origin"
+    },
+    "preview_api_eyebrow": {
+        "message": "Direct API"
+    },
+    "preview_api_title": {
+        "message": "Send with your own API key"
+    },
+    "preview_api_description": {
+        "message": "Send the prompt straight to a provider and read the answer here, without opening an AI chat tab."
+    },
+    "preview_api_provider_label": {
+        "message": "API provider"
+    },
+    "preview_api_send": {
+        "message": "Send via API"
+    },
+    "preview_api_no_key": {
+        "message": "No API key is configured for this provider."
+    },
+    "preview_api_no_key_for": {
+        "message": "No API key is configured for $1."
+    },
+    "preview_api_open_options": {
+        "message": "Add a key in options"
+    },
+    "preview_api_loading": {
+        "message": "Waiting for the AI response…"
+    },
+    "preview_api_retry": {
+        "message": "Retry"
+    },
+    "preview_api_retryable": {
+        "message": "This looks temporary — try again in a moment."
+    },
+    "preview_api_copy": {
+        "message": "Copy response"
+    },
+    "preview_api_copied": {
+        "message": "API response copied to clipboard."
+    },
+    "preview_api_refused": {
+        "message": "The provider declined to answer this request."
+    },
+    "preview_api_empty_response": {
+        "message": "The provider returned an empty response."
+    },
+    "preview_api_empty_prompt": {
+        "message": "Prompt is empty."
+    },
+    "preview_api_truncated": {
+        "message": "truncated at the token limit"
+    },
+    "preview_api_failed": {
+        "message": "The API request failed."
+    },
+    "preview_api_status_sending": {
+        "message": "Sending the prompt to the API…"
+    },
+    "preview_api_status_done": {
+        "message": "API response received."
+    },
+    "preview_api_status_failed": {
+        "message": "API request failed."
+    },
+    "options_card_direct_api_title": {
+        "message": "Direct API"
+    },
+    "options_direct_api_intro": {
+        "message": "Add your own provider API key to get answers inside the prompt preview page, without opening an AI chat tab."
+    },
+    "options_direct_api_warning": {
+        "message": "Keys are stored locally on this device only — they are never synced to your Google account and never included in a settings export. Requests go directly from your browser to the provider, and you are billed by that provider."
+    },
+    "options_direct_api_key_label": {
+        "message": "API key"
+    },
+    "options_direct_api_key_placeholder": {
+        "message": "Paste your API key"
+    },
+    "options_direct_api_model_label": {
+        "message": "Model"
+    },
+    "options_direct_api_model_hint": {
+        "message": "Any model id this provider accepts."
+    },
+    "options_direct_api_show": {
+        "message": "Show"
+    },
+    "options_direct_api_hide": {
+        "message": "Hide"
+    },
+    "options_direct_api_test": {
+        "message": "Test key"
+    },
+    "options_direct_api_testing": {
+        "message": "Testing"
+    },
+    "options_direct_api_test_ok": {
+        "message": "Key works."
+    },
+    "options_direct_api_test_no_key": {
+        "message": "Enter an API key first."
+    },
+    "options_direct_api_clear": {
+        "message": "Remove key"
+    },
+    "options_direct_api_cleared": {
+        "message": "Key removed."
     }
 }

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -552,5 +552,145 @@
     },
     "error": {
         "message": "Error"
+    },
+    "popup_preset_name_label": {
+        "message": "Nombre del ajuste",
+        "description": "Label for the inline preset-name field in the popup"
+    },
+    "popup_preset_name_placeholder": {
+        "message": "Nombre del ajuste",
+        "description": "Placeholder for the inline preset-name field"
+    },
+    "popup_preset_name_confirm": {
+        "message": "Guardar",
+        "description": "Confirm button for saving a quick prompt as a preset"
+    },
+    "popup_preset_name_cancel": {
+        "message": "Cancelar",
+        "description": "Cancel button for the inline preset-name field"
+    },
+    "popup_preset_name_default": {
+        "message": "Prompt rápido",
+        "description": "Fallback name suggested when saving a quick prompt preset"
+    },
+    "command_scrape_current_thread": {
+        "message": "Extraer el hilo de Reddit actual",
+        "description": "Description for the keyboard shortcut that scrapes the active Reddit thread"
+    },
+    "context_menu_scrape_thread": {
+        "message": "Extraer este hilo con Reddit to AI",
+        "description": "Right-click menu entry that scrapes a Reddit thread"
+    },
+    "sw_error_custom_origin_missing": {
+        "message": "No hay ningún origen de IA personalizado configurado. Añade uno en Opciones antes de usar el proveedor personalizado.",
+        "description": "Error shown when the custom AI provider is selected without a configured origin"
+    },
+    "preview_api_eyebrow": {
+        "message": "API directa"
+    },
+    "preview_api_title": {
+        "message": "Enviar con tu propia clave de API"
+    },
+    "preview_api_description": {
+        "message": "Envía el prompt directamente a un proveedor y lee la respuesta aquí, sin abrir una pestaña de chat de IA."
+    },
+    "preview_api_provider_label": {
+        "message": "Proveedor de API"
+    },
+    "preview_api_send": {
+        "message": "Enviar por API"
+    },
+    "preview_api_no_key": {
+        "message": "No hay ninguna clave de API configurada para este proveedor."
+    },
+    "preview_api_no_key_for": {
+        "message": "No hay ninguna clave de API configurada para $1."
+    },
+    "preview_api_open_options": {
+        "message": "Añadir una clave en las opciones"
+    },
+    "preview_api_loading": {
+        "message": "Esperando la respuesta de la IA…"
+    },
+    "preview_api_retry": {
+        "message": "Reintentar"
+    },
+    "preview_api_retryable": {
+        "message": "Parece temporal: inténtalo de nuevo en un momento."
+    },
+    "preview_api_copy": {
+        "message": "Copiar respuesta"
+    },
+    "preview_api_copied": {
+        "message": "Respuesta de la API copiada al portapapeles."
+    },
+    "preview_api_refused": {
+        "message": "El proveedor se negó a responder esta solicitud."
+    },
+    "preview_api_empty_response": {
+        "message": "El proveedor devolvió una respuesta vacía."
+    },
+    "preview_api_empty_prompt": {
+        "message": "El prompt está vacío."
+    },
+    "preview_api_truncated": {
+        "message": "truncado en el límite de tokens"
+    },
+    "preview_api_failed": {
+        "message": "La solicitud a la API falló."
+    },
+    "preview_api_status_sending": {
+        "message": "Enviando el prompt a la API…"
+    },
+    "preview_api_status_done": {
+        "message": "Respuesta de la API recibida."
+    },
+    "preview_api_status_failed": {
+        "message": "La solicitud a la API falló."
+    },
+    "options_card_direct_api_title": {
+        "message": "API directa"
+    },
+    "options_direct_api_intro": {
+        "message": "Añade tu propia clave de API del proveedor para obtener respuestas en la página de vista previa del prompt, sin abrir una pestaña de chat de IA."
+    },
+    "options_direct_api_warning": {
+        "message": "Las claves se guardan solo localmente en este dispositivo: nunca se sincronizan con tu cuenta de Google ni se incluyen en una exportación de ajustes. Las solicitudes van directamente de tu navegador al proveedor, y ese proveedor te factura."
+    },
+    "options_direct_api_key_label": {
+        "message": "Clave de API"
+    },
+    "options_direct_api_key_placeholder": {
+        "message": "Pega tu clave de API"
+    },
+    "options_direct_api_model_label": {
+        "message": "Modelo"
+    },
+    "options_direct_api_model_hint": {
+        "message": "Cualquier id de modelo que acepte este proveedor."
+    },
+    "options_direct_api_show": {
+        "message": "Mostrar"
+    },
+    "options_direct_api_hide": {
+        "message": "Ocultar"
+    },
+    "options_direct_api_test": {
+        "message": "Probar clave"
+    },
+    "options_direct_api_testing": {
+        "message": "Probando"
+    },
+    "options_direct_api_test_ok": {
+        "message": "La clave funciona."
+    },
+    "options_direct_api_test_no_key": {
+        "message": "Introduce primero una clave de API."
+    },
+    "options_direct_api_clear": {
+        "message": "Eliminar clave"
+    },
+    "options_direct_api_cleared": {
+        "message": "Clave eliminada."
     }
 }

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -552,5 +552,145 @@
     },
     "error": {
         "message": "Error"
+    },
+    "popup_preset_name_label": {
+        "message": "Nom du préréglage",
+        "description": "Label for the inline preset-name field in the popup"
+    },
+    "popup_preset_name_placeholder": {
+        "message": "Nom du préréglage",
+        "description": "Placeholder for the inline preset-name field"
+    },
+    "popup_preset_name_confirm": {
+        "message": "Enregistrer",
+        "description": "Confirm button for saving a quick prompt as a preset"
+    },
+    "popup_preset_name_cancel": {
+        "message": "Annuler",
+        "description": "Cancel button for the inline preset-name field"
+    },
+    "popup_preset_name_default": {
+        "message": "Prompt rapide",
+        "description": "Fallback name suggested when saving a quick prompt preset"
+    },
+    "command_scrape_current_thread": {
+        "message": "Extraire le fil Reddit actuel",
+        "description": "Description for the keyboard shortcut that scrapes the active Reddit thread"
+    },
+    "context_menu_scrape_thread": {
+        "message": "Extraire ce fil avec Reddit to AI",
+        "description": "Right-click menu entry that scrapes a Reddit thread"
+    },
+    "sw_error_custom_origin_missing": {
+        "message": "Aucune origine d'IA personnalisée n'est configurée. Ajoutez-en une dans les Options avant d'utiliser le fournisseur personnalisé.",
+        "description": "Error shown when the custom AI provider is selected without a configured origin"
+    },
+    "preview_api_eyebrow": {
+        "message": "API directe"
+    },
+    "preview_api_title": {
+        "message": "Envoyer avec votre propre clé API"
+    },
+    "preview_api_description": {
+        "message": "Envoyez le prompt directement à un fournisseur et lisez la réponse ici, sans ouvrir d'onglet de chat IA."
+    },
+    "preview_api_provider_label": {
+        "message": "Fournisseur d'API"
+    },
+    "preview_api_send": {
+        "message": "Envoyer via l'API"
+    },
+    "preview_api_no_key": {
+        "message": "Aucune clé API n'est configurée pour ce fournisseur."
+    },
+    "preview_api_no_key_for": {
+        "message": "Aucune clé API n'est configurée pour $1."
+    },
+    "preview_api_open_options": {
+        "message": "Ajouter une clé dans les options"
+    },
+    "preview_api_loading": {
+        "message": "En attente de la réponse de l'IA…"
+    },
+    "preview_api_retry": {
+        "message": "Réessayer"
+    },
+    "preview_api_retryable": {
+        "message": "Cela semble temporaire — réessayez dans un instant."
+    },
+    "preview_api_copy": {
+        "message": "Copier la réponse"
+    },
+    "preview_api_copied": {
+        "message": "Réponse de l'API copiée dans le presse-papiers."
+    },
+    "preview_api_refused": {
+        "message": "Le fournisseur a refusé de répondre à cette demande."
+    },
+    "preview_api_empty_response": {
+        "message": "Le fournisseur a renvoyé une réponse vide."
+    },
+    "preview_api_empty_prompt": {
+        "message": "Le prompt est vide."
+    },
+    "preview_api_truncated": {
+        "message": "tronqué à la limite de jetons"
+    },
+    "preview_api_failed": {
+        "message": "La requête API a échoué."
+    },
+    "preview_api_status_sending": {
+        "message": "Envoi du prompt à l'API…"
+    },
+    "preview_api_status_done": {
+        "message": "Réponse de l'API reçue."
+    },
+    "preview_api_status_failed": {
+        "message": "La requête API a échoué."
+    },
+    "options_card_direct_api_title": {
+        "message": "API directe"
+    },
+    "options_direct_api_intro": {
+        "message": "Ajoutez votre propre clé API pour obtenir les réponses dans la page d'aperçu du prompt, sans ouvrir d'onglet de chat IA."
+    },
+    "options_direct_api_warning": {
+        "message": "Les clés sont stockées uniquement en local sur cet appareil — elles ne sont jamais synchronisées avec votre compte Google ni incluses dans un export de paramètres. Les requêtes vont directement de votre navigateur au fournisseur, qui vous facture."
+    },
+    "options_direct_api_key_label": {
+        "message": "Clé API"
+    },
+    "options_direct_api_key_placeholder": {
+        "message": "Collez votre clé API"
+    },
+    "options_direct_api_model_label": {
+        "message": "Modèle"
+    },
+    "options_direct_api_model_hint": {
+        "message": "Tout identifiant de modèle accepté par ce fournisseur."
+    },
+    "options_direct_api_show": {
+        "message": "Afficher"
+    },
+    "options_direct_api_hide": {
+        "message": "Masquer"
+    },
+    "options_direct_api_test": {
+        "message": "Tester la clé"
+    },
+    "options_direct_api_testing": {
+        "message": "Test en cours"
+    },
+    "options_direct_api_test_ok": {
+        "message": "La clé fonctionne."
+    },
+    "options_direct_api_test_no_key": {
+        "message": "Saisissez d'abord une clé API."
+    },
+    "options_direct_api_clear": {
+        "message": "Supprimer la clé"
+    },
+    "options_direct_api_cleared": {
+        "message": "Clé supprimée."
     }
 }

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -552,5 +552,145 @@
     },
     "error": {
         "message": "Error"
+    },
+    "popup_preset_name_label": {
+        "message": "プリセット名",
+        "description": "Label for the inline preset-name field in the popup"
+    },
+    "popup_preset_name_placeholder": {
+        "message": "プリセット名",
+        "description": "Placeholder for the inline preset-name field"
+    },
+    "popup_preset_name_confirm": {
+        "message": "保存",
+        "description": "Confirm button for saving a quick prompt as a preset"
+    },
+    "popup_preset_name_cancel": {
+        "message": "キャンセル",
+        "description": "Cancel button for the inline preset-name field"
+    },
+    "popup_preset_name_default": {
+        "message": "クイックプロンプト",
+        "description": "Fallback name suggested when saving a quick prompt preset"
+    },
+    "command_scrape_current_thread": {
+        "message": "現在のRedditスレッドを取得",
+        "description": "Description for the keyboard shortcut that scrapes the active Reddit thread"
+    },
+    "context_menu_scrape_thread": {
+        "message": "このスレッドをReddit to AIで取得",
+        "description": "Right-click menu entry that scrapes a Reddit thread"
+    },
+    "sw_error_custom_origin_missing": {
+        "message": "カスタムAIのオリジンが設定されていません。カスタムプロバイダーを使う前にオプションで追加してください。",
+        "description": "Error shown when the custom AI provider is selected without a configured origin"
+    },
+    "preview_api_eyebrow": {
+        "message": "ダイレクトAPI"
+    },
+    "preview_api_title": {
+        "message": "自分のAPIキーで送信"
+    },
+    "preview_api_description": {
+        "message": "AIチャットのタブを開かずに、プロンプトをプロバイダーへ直接送信し、ここで回答を読めます。"
+    },
+    "preview_api_provider_label": {
+        "message": "APIプロバイダー"
+    },
+    "preview_api_send": {
+        "message": "APIで送信"
+    },
+    "preview_api_no_key": {
+        "message": "このプロバイダーのAPIキーが設定されていません。"
+    },
+    "preview_api_no_key_for": {
+        "message": "$1 のAPIキーが設定されていません。"
+    },
+    "preview_api_open_options": {
+        "message": "オプションでキーを追加"
+    },
+    "preview_api_loading": {
+        "message": "AIの応答を待っています…"
+    },
+    "preview_api_retry": {
+        "message": "再試行"
+    },
+    "preview_api_retryable": {
+        "message": "一時的な問題のようです。少し待って再試行してください。"
+    },
+    "preview_api_copy": {
+        "message": "回答をコピー"
+    },
+    "preview_api_copied": {
+        "message": "APIの回答をクリップボードにコピーしました。"
+    },
+    "preview_api_refused": {
+        "message": "プロバイダーはこのリクエストへの回答を拒否しました。"
+    },
+    "preview_api_empty_response": {
+        "message": "プロバイダーから空の応答が返されました。"
+    },
+    "preview_api_empty_prompt": {
+        "message": "プロンプトが空です。"
+    },
+    "preview_api_truncated": {
+        "message": "トークン上限で切り詰められました"
+    },
+    "preview_api_failed": {
+        "message": "APIリクエストが失敗しました。"
+    },
+    "preview_api_status_sending": {
+        "message": "プロンプトをAPIへ送信しています…"
+    },
+    "preview_api_status_done": {
+        "message": "APIの応答を受信しました。"
+    },
+    "preview_api_status_failed": {
+        "message": "APIリクエストが失敗しました。"
+    },
+    "options_card_direct_api_title": {
+        "message": "ダイレクトAPI"
+    },
+    "options_direct_api_intro": {
+        "message": "自分のAPIキーを追加すると、AIチャットのタブを開かずにプロンプトのプレビュー画面で回答を受け取れます。"
+    },
+    "options_direct_api_warning": {
+        "message": "キーはこの端末のローカルにのみ保存されます。Googleアカウントに同期されることも、設定のエクスポートに含まれることもありません。リクエストはブラウザからプロバイダーへ直接送信され、料金はそのプロバイダーから請求されます。"
+    },
+    "options_direct_api_key_label": {
+        "message": "APIキー"
+    },
+    "options_direct_api_key_placeholder": {
+        "message": "APIキーを貼り付け"
+    },
+    "options_direct_api_model_label": {
+        "message": "モデル"
+    },
+    "options_direct_api_model_hint": {
+        "message": "このプロバイダーが受け付ける任意のモデルID。"
+    },
+    "options_direct_api_show": {
+        "message": "表示"
+    },
+    "options_direct_api_hide": {
+        "message": "非表示"
+    },
+    "options_direct_api_test": {
+        "message": "キーをテスト"
+    },
+    "options_direct_api_testing": {
+        "message": "テスト中"
+    },
+    "options_direct_api_test_ok": {
+        "message": "キーは有効です。"
+    },
+    "options_direct_api_test_no_key": {
+        "message": "先にAPIキーを入力してください。"
+    },
+    "options_direct_api_clear": {
+        "message": "キーを削除"
+    },
+    "options_direct_api_cleared": {
+        "message": "キーを削除しました。"
     }
 }

--- a/src/_locales/pt/messages.json
+++ b/src/_locales/pt/messages.json
@@ -552,5 +552,145 @@
     },
     "error": {
         "message": "Error"
+    },
+    "popup_preset_name_label": {
+        "message": "Nome da predefinição",
+        "description": "Label for the inline preset-name field in the popup"
+    },
+    "popup_preset_name_placeholder": {
+        "message": "Nome da predefinição",
+        "description": "Placeholder for the inline preset-name field"
+    },
+    "popup_preset_name_confirm": {
+        "message": "Guardar",
+        "description": "Confirm button for saving a quick prompt as a preset"
+    },
+    "popup_preset_name_cancel": {
+        "message": "Cancelar",
+        "description": "Cancel button for the inline preset-name field"
+    },
+    "popup_preset_name_default": {
+        "message": "Prompt rápido",
+        "description": "Fallback name suggested when saving a quick prompt preset"
+    },
+    "command_scrape_current_thread": {
+        "message": "Extrair o tópico do Reddit atual",
+        "description": "Description for the keyboard shortcut that scrapes the active Reddit thread"
+    },
+    "context_menu_scrape_thread": {
+        "message": "Extrair este tópico com o Reddit to AI",
+        "description": "Right-click menu entry that scrapes a Reddit thread"
+    },
+    "sw_error_custom_origin_missing": {
+        "message": "Nenhuma origem de IA personalizada está configurada. Adicione uma nas Opções antes de usar o provedor personalizado.",
+        "description": "Error shown when the custom AI provider is selected without a configured origin"
+    },
+    "preview_api_eyebrow": {
+        "message": "API direta"
+    },
+    "preview_api_title": {
+        "message": "Enviar com sua própria chave de API"
+    },
+    "preview_api_description": {
+        "message": "Envie o prompt diretamente a um provedor e leia a resposta aqui, sem abrir uma aba de chat de IA."
+    },
+    "preview_api_provider_label": {
+        "message": "Provedor de API"
+    },
+    "preview_api_send": {
+        "message": "Enviar via API"
+    },
+    "preview_api_no_key": {
+        "message": "Nenhuma chave de API está configurada para este provedor."
+    },
+    "preview_api_no_key_for": {
+        "message": "Nenhuma chave de API está configurada para $1."
+    },
+    "preview_api_open_options": {
+        "message": "Adicionar uma chave nas opções"
+    },
+    "preview_api_loading": {
+        "message": "Aguardando a resposta da IA…"
+    },
+    "preview_api_retry": {
+        "message": "Tentar novamente"
+    },
+    "preview_api_retryable": {
+        "message": "Parece temporário — tente novamente em instantes."
+    },
+    "preview_api_copy": {
+        "message": "Copiar resposta"
+    },
+    "preview_api_copied": {
+        "message": "Resposta da API copiada para a área de transferência."
+    },
+    "preview_api_refused": {
+        "message": "O provedor recusou-se a responder a esta solicitação."
+    },
+    "preview_api_empty_response": {
+        "message": "O provedor retornou uma resposta vazia."
+    },
+    "preview_api_empty_prompt": {
+        "message": "O prompt está vazio."
+    },
+    "preview_api_truncated": {
+        "message": "truncado no limite de tokens"
+    },
+    "preview_api_failed": {
+        "message": "A solicitação à API falhou."
+    },
+    "preview_api_status_sending": {
+        "message": "Enviando o prompt para a API…"
+    },
+    "preview_api_status_done": {
+        "message": "Resposta da API recebida."
+    },
+    "preview_api_status_failed": {
+        "message": "A solicitação à API falhou."
+    },
+    "options_card_direct_api_title": {
+        "message": "API direta"
+    },
+    "options_direct_api_intro": {
+        "message": "Adicione sua própria chave de API do provedor para obter respostas na página de pré-visualização do prompt, sem abrir uma aba de chat de IA."
+    },
+    "options_direct_api_warning": {
+        "message": "As chaves são armazenadas apenas localmente neste dispositivo — nunca são sincronizadas com sua conta Google nem incluídas em uma exportação de configurações. As solicitações vão diretamente do seu navegador para o provedor, e esse provedor cobra de você."
+    },
+    "options_direct_api_key_label": {
+        "message": "Chave de API"
+    },
+    "options_direct_api_key_placeholder": {
+        "message": "Cole sua chave de API"
+    },
+    "options_direct_api_model_label": {
+        "message": "Modelo"
+    },
+    "options_direct_api_model_hint": {
+        "message": "Qualquer id de modelo que este provedor aceite."
+    },
+    "options_direct_api_show": {
+        "message": "Mostrar"
+    },
+    "options_direct_api_hide": {
+        "message": "Ocultar"
+    },
+    "options_direct_api_test": {
+        "message": "Testar chave"
+    },
+    "options_direct_api_testing": {
+        "message": "Testando"
+    },
+    "options_direct_api_test_ok": {
+        "message": "A chave funciona."
+    },
+    "options_direct_api_test_no_key": {
+        "message": "Insira primeiro uma chave de API."
+    },
+    "options_direct_api_clear": {
+        "message": "Remover chave"
+    },
+    "options_direct_api_cleared": {
+        "message": "Chave removida."
     }
 }

--- a/src/_locales/tr/messages.json
+++ b/src/_locales/tr/messages.json
@@ -552,5 +552,145 @@
     },
     "error": {
         "message": "Error"
+    },
+    "popup_preset_name_label": {
+        "message": "Hazır ayar adı",
+        "description": "Label for the inline preset-name field in the popup"
+    },
+    "popup_preset_name_placeholder": {
+        "message": "Hazır ayar adı",
+        "description": "Placeholder for the inline preset-name field"
+    },
+    "popup_preset_name_confirm": {
+        "message": "Kaydet",
+        "description": "Confirm button for saving a quick prompt as a preset"
+    },
+    "popup_preset_name_cancel": {
+        "message": "İptal",
+        "description": "Cancel button for the inline preset-name field"
+    },
+    "popup_preset_name_default": {
+        "message": "Hızlı istem",
+        "description": "Fallback name suggested when saving a quick prompt preset"
+    },
+    "command_scrape_current_thread": {
+        "message": "Geçerli Reddit başlığını topla",
+        "description": "Description for the keyboard shortcut that scrapes the active Reddit thread"
+    },
+    "context_menu_scrape_thread": {
+        "message": "Bu başlığı Reddit to AI ile topla",
+        "description": "Right-click menu entry that scrapes a Reddit thread"
+    },
+    "sw_error_custom_origin_missing": {
+        "message": "Yapılandırılmış özel bir yapay zekâ kaynağı yok. Özel sağlayıcıyı kullanmadan önce Seçenekler bölümünden ekleyin.",
+        "description": "Error shown when the custom AI provider is selected without a configured origin"
+    },
+    "preview_api_eyebrow": {
+        "message": "Doğrudan API"
+    },
+    "preview_api_title": {
+        "message": "Kendi API anahtarınla gönder"
+    },
+    "preview_api_description": {
+        "message": "İstemi doğrudan bir sağlayıcıya gönderin ve yapay zeka sohbet sekmesi açmadan yanıtı burada okuyun."
+    },
+    "preview_api_provider_label": {
+        "message": "API sağlayıcısı"
+    },
+    "preview_api_send": {
+        "message": "API ile gönder"
+    },
+    "preview_api_no_key": {
+        "message": "Bu sağlayıcı için API anahtarı yapılandırılmamış."
+    },
+    "preview_api_no_key_for": {
+        "message": "$1 için API anahtarı yapılandırılmamış."
+    },
+    "preview_api_open_options": {
+        "message": "Seçeneklerde anahtar ekle"
+    },
+    "preview_api_loading": {
+        "message": "Yapay zeka yanıtı bekleniyor…"
+    },
+    "preview_api_retry": {
+        "message": "Yeniden dene"
+    },
+    "preview_api_retryable": {
+        "message": "Bu geçici görünüyor — birazdan tekrar deneyin."
+    },
+    "preview_api_copy": {
+        "message": "Yanıtı kopyala"
+    },
+    "preview_api_copied": {
+        "message": "API yanıtı panoya kopyalandı."
+    },
+    "preview_api_refused": {
+        "message": "Sağlayıcı bu isteği yanıtlamayı reddetti."
+    },
+    "preview_api_empty_response": {
+        "message": "Sağlayıcı boş bir yanıt döndürdü."
+    },
+    "preview_api_empty_prompt": {
+        "message": "İstem boş."
+    },
+    "preview_api_truncated": {
+        "message": "belirteç sınırında kesildi"
+    },
+    "preview_api_failed": {
+        "message": "API isteği başarısız oldu."
+    },
+    "preview_api_status_sending": {
+        "message": "İstem API'ye gönderiliyor…"
+    },
+    "preview_api_status_done": {
+        "message": "API yanıtı alındı."
+    },
+    "preview_api_status_failed": {
+        "message": "API isteği başarısız oldu."
+    },
+    "options_card_direct_api_title": {
+        "message": "Doğrudan API"
+    },
+    "options_direct_api_intro": {
+        "message": "Kendi sağlayıcı API anahtarınızı ekleyerek, yapay zeka sohbet sekmesi açmadan istem önizleme sayfasında yanıt alın."
+    },
+    "options_direct_api_warning": {
+        "message": "Anahtarlar yalnızca bu cihazda yerel olarak saklanır — Google hesabınıza asla eşitlenmez ve ayar dışa aktarımına asla dahil edilmez. İstekler tarayıcınızdan doğrudan sağlayıcıya gider ve ücretlendirme o sağlayıcı tarafından yapılır."
+    },
+    "options_direct_api_key_label": {
+        "message": "API anahtarı"
+    },
+    "options_direct_api_key_placeholder": {
+        "message": "API anahtarınızı yapıştırın"
+    },
+    "options_direct_api_model_label": {
+        "message": "Model"
+    },
+    "options_direct_api_model_hint": {
+        "message": "Bu sağlayıcının kabul ettiği herhangi bir model kimliği."
+    },
+    "options_direct_api_show": {
+        "message": "Göster"
+    },
+    "options_direct_api_hide": {
+        "message": "Gizle"
+    },
+    "options_direct_api_test": {
+        "message": "Anahtarı test et"
+    },
+    "options_direct_api_testing": {
+        "message": "Test ediliyor"
+    },
+    "options_direct_api_test_ok": {
+        "message": "Anahtar çalışıyor."
+    },
+    "options_direct_api_test_no_key": {
+        "message": "Önce bir API anahtarı girin."
+    },
+    "options_direct_api_clear": {
+        "message": "Anahtarı kaldır"
+    },
+    "options_direct_api_cleared": {
+        "message": "Anahtar kaldırıldı."
     }
 }

--- a/src/_locales/zh_CN/messages.json
+++ b/src/_locales/zh_CN/messages.json
@@ -552,5 +552,145 @@
     },
     "error": {
         "message": "Error"
+    },
+    "popup_preset_name_label": {
+        "message": "预设名称",
+        "description": "Label for the inline preset-name field in the popup"
+    },
+    "popup_preset_name_placeholder": {
+        "message": "预设名称",
+        "description": "Placeholder for the inline preset-name field"
+    },
+    "popup_preset_name_confirm": {
+        "message": "保存",
+        "description": "Confirm button for saving a quick prompt as a preset"
+    },
+    "popup_preset_name_cancel": {
+        "message": "取消",
+        "description": "Cancel button for the inline preset-name field"
+    },
+    "popup_preset_name_default": {
+        "message": "快速提示词",
+        "description": "Fallback name suggested when saving a quick prompt preset"
+    },
+    "command_scrape_current_thread": {
+        "message": "抓取当前 Reddit 帖子",
+        "description": "Description for the keyboard shortcut that scrapes the active Reddit thread"
+    },
+    "context_menu_scrape_thread": {
+        "message": "使用 Reddit to AI 抓取此帖子",
+        "description": "Right-click menu entry that scrapes a Reddit thread"
+    },
+    "sw_error_custom_origin_missing": {
+        "message": "尚未配置自定义 AI 来源。请先在选项中添加后再使用自定义提供商。",
+        "description": "Error shown when the custom AI provider is selected without a configured origin"
+    },
+    "preview_api_eyebrow": {
+        "message": "直接 API"
+    },
+    "preview_api_title": {
+        "message": "使用你自己的 API 密钥发送"
+    },
+    "preview_api_description": {
+        "message": "将提示词直接发送给服务商并在此处阅读回复，无需打开 AI 聊天标签页。"
+    },
+    "preview_api_provider_label": {
+        "message": "API 服务商"
+    },
+    "preview_api_send": {
+        "message": "通过 API 发送"
+    },
+    "preview_api_no_key": {
+        "message": "尚未为此服务商配置 API 密钥。"
+    },
+    "preview_api_no_key_for": {
+        "message": "尚未为 $1 配置 API 密钥。"
+    },
+    "preview_api_open_options": {
+        "message": "在选项中添加密钥"
+    },
+    "preview_api_loading": {
+        "message": "正在等待 AI 回复…"
+    },
+    "preview_api_retry": {
+        "message": "重试"
+    },
+    "preview_api_retryable": {
+        "message": "这看起来是暂时问题，请稍后重试。"
+    },
+    "preview_api_copy": {
+        "message": "复制回复"
+    },
+    "preview_api_copied": {
+        "message": "已将 API 回复复制到剪贴板。"
+    },
+    "preview_api_refused": {
+        "message": "服务商拒绝回答此请求。"
+    },
+    "preview_api_empty_response": {
+        "message": "服务商返回了空回复。"
+    },
+    "preview_api_empty_prompt": {
+        "message": "提示词为空。"
+    },
+    "preview_api_truncated": {
+        "message": "已在令牌上限处截断"
+    },
+    "preview_api_failed": {
+        "message": "API 请求失败。"
+    },
+    "preview_api_status_sending": {
+        "message": "正在将提示词发送到 API…"
+    },
+    "preview_api_status_done": {
+        "message": "已收到 API 回复。"
+    },
+    "preview_api_status_failed": {
+        "message": "API 请求失败。"
+    },
+    "options_card_direct_api_title": {
+        "message": "直接 API"
+    },
+    "options_direct_api_intro": {
+        "message": "添加你自己的服务商 API 密钥，即可在提示词预览页面中获得回复，无需打开 AI 聊天标签页。"
+    },
+    "options_direct_api_warning": {
+        "message": "密钥仅存储在本设备本地——绝不会同步到你的 Google 账户，也不会包含在设置导出中。请求由你的浏览器直接发送至服务商，费用由该服务商向你收取。"
+    },
+    "options_direct_api_key_label": {
+        "message": "API 密钥"
+    },
+    "options_direct_api_key_placeholder": {
+        "message": "粘贴你的 API 密钥"
+    },
+    "options_direct_api_model_label": {
+        "message": "模型"
+    },
+    "options_direct_api_model_hint": {
+        "message": "此服务商接受的任意模型 ID。"
+    },
+    "options_direct_api_show": {
+        "message": "显示"
+    },
+    "options_direct_api_hide": {
+        "message": "隐藏"
+    },
+    "options_direct_api_test": {
+        "message": "测试密钥"
+    },
+    "options_direct_api_testing": {
+        "message": "正在测试"
+    },
+    "options_direct_api_test_ok": {
+        "message": "密钥可用。"
+    },
+    "options_direct_api_test_no_key": {
+        "message": "请先输入 API 密钥。"
+    },
+    "options_direct_api_clear": {
+        "message": "移除密钥"
+    },
+    "options_direct_api_cleared": {
+        "message": "密钥已移除。"
     }
 }

--- a/src/aiPaster.js
+++ b/src/aiPaster.js
@@ -3,7 +3,8 @@ console.log('Reddit to AI: aiPaster.js loaded.');
 
 const MAX_IMAGES = 10;
 const IMAGE_PASTE_DELAY = 500;
-const INPUT_RETRY_LIMIT = 7;
+const INPUT_WAIT_TIMEOUT = 20000;
+const INPUT_POLL_INTERVAL = 400;
 
 if (!globalThis.R2AIAiPasterTest) {
     setTimeout(initPaster, 1500);
@@ -72,17 +73,15 @@ async function attemptPaste(payload) {
         return;
     }
 
-    const loginProblem = detectLoginRequired();
-    if (loginProblem) {
-        await recordPasteFailure(payload, loginProblem);
-        showPasteFallback(promptText, loginProblem, payload);
-        return;
-    }
-
+    // The composer search runs first. Login detection is heuristic and false-positives
+    // on signed-in pages (a footer "sign in" link, an /auth/ path), so it is only
+    // consulted afterwards, to explain why no composer ever showed up.
     const inputEl = await waitForInput(target.inputSelector);
     if (!inputEl) {
-        await recordPasteFailure(payload, 'Input box was not found. You may need to sign in or start a new chat.');
-        showPasteFallback(promptText, 'Auto-paste failed — click Copy Prompt.', payload);
+        const loginProblem = detectLoginRequired();
+        const reason = loginProblem || 'Input box was not found. You may need to start a new chat.';
+        await recordPasteFailure(payload, reason);
+        showPasteFallback(promptText, reason, payload);
         return;
     }
 
@@ -249,13 +248,143 @@ async function getPlatformInputTarget() {
     return merged;
 }
 
-async function waitForInput(selector) {
-    for (let attempt = 0; attempt < INPUT_RETRY_LIMIT; attempt++) {
-        const inputEl = document.querySelector(selector);
-        if (inputEl) return inputEl;
-        await delay(900 + attempt * 200);
+// Composer hints that appear in aria-label / placeholder text across the AI chat
+// UIs we target. A match is strong evidence the element is the prompt box rather
+// than some other editable on the page (a rename field, a search box, ...).
+const COMPOSER_HINTS = ['prompt', 'message', 'chat', 'ask', 'send a', 'talk to', 'reply'];
+
+function collectCandidates(selector) {
+    if (typeof document.querySelectorAll === 'function') {
+        return Array.from(document.querySelectorAll(selector) || []);
     }
-    return null;
+    const single = document.querySelector(selector);
+    return single ? [single] : [];
+}
+
+// Visibility is best-effort: an element only counts as hidden when the DOM
+// actually tells us so. When neither layout API is available we assume visible,
+// because treating "unknown" as hidden would reject every viable candidate.
+function isVisibleCandidate(el) {
+    if (!el) return false;
+    if (el.hidden === true) return false;
+    if ('offsetParent' in el && el.offsetParent === null) {
+        // position:fixed elements legitimately report a null offsetParent, so only
+        // trust this signal when there is no measurable box either.
+        const rect = typeof el.getBoundingClientRect === 'function' ? el.getBoundingClientRect() : null;
+        if (!rect || (!rect.width && !rect.height)) return false;
+    }
+    if (typeof el.getBoundingClientRect === 'function') {
+        const rect = el.getBoundingClientRect();
+        if (rect && rect.width === 0 && rect.height === 0) return false;
+    }
+    return true;
+}
+
+function describeCandidate(el) {
+    const parts = [
+        el.getAttribute?.('aria-label'),
+        el.getAttribute?.('placeholder'),
+        el.getAttribute?.('aria-placeholder'),
+        el.getAttribute?.('data-placeholder'),
+        el.getAttribute?.('name'),
+        el.getAttribute?.('id')
+    ];
+    return parts.filter(Boolean).join(' ').toLowerCase();
+}
+
+// Higher is better. The weights are ordered so an explicitly-labelled composer
+// always beats a bare contenteditable, and a large box near the bottom of the
+// viewport beats a small one tucked away in a corner.
+function scoreCandidate(el) {
+    let score = 0;
+
+    if (el.getAttribute?.('role') === 'textbox') score += 4;
+
+    const description = describeCandidate(el);
+    if (COMPOSER_HINTS.some(hint => description.includes(hint))) score += 4;
+
+    const tagName = String(el.tagName || '').toUpperCase();
+    if (tagName === 'TEXTAREA') score += 3;
+
+    const className = typeof el.className === 'string' ? el.className.toLowerCase() : '';
+    if (className.includes('prosemirror') || className.includes('ql-editor')) score += 3;
+
+    if (el.getAttribute?.('contenteditable') === 'true' || el.isContentEditable === true) score += 1;
+
+    const rect = typeof el.getBoundingClientRect === 'function' ? el.getBoundingClientRect() : null;
+    if (rect && (rect.width || rect.height)) {
+        const area = (rect.width || 0) * (rect.height || 0);
+        // Saturates around a typical composer footprint (~600x120).
+        score += Math.min(3, area / 24000);
+
+        const viewportHeight = (typeof window !== 'undefined' && window.innerHeight) || 0;
+        if (viewportHeight) {
+            // Composers live near the bottom of the page; the closer the better.
+            const distanceFromBottom = Math.max(0, viewportHeight - (rect.bottom || 0));
+            score += Math.min(3, 3 * (1 - Math.min(1, distanceFromBottom / viewportHeight)));
+        }
+    }
+
+    return score;
+}
+
+function pickBestCandidate(selector) {
+    const candidates = collectCandidates(selector).filter(isVisibleCandidate);
+    if (candidates.length === 0) return null;
+    if (candidates.length === 1) return candidates[0];
+
+    let best = null;
+    let bestScore = -Infinity;
+    for (const candidate of candidates) {
+        const score = scoreCandidate(candidate);
+        if (score > bestScore) {
+            best = candidate;
+            bestScore = score;
+        }
+    }
+    return best;
+}
+
+// Resolves as soon as a viable composer exists rather than after a fixed number of
+// sleeps, so a fast page is not penalised and a slow one still gets the full budget.
+function waitForInput(selector, timeoutMs = INPUT_WAIT_TIMEOUT) {
+    const immediate = pickBestCandidate(selector);
+    if (immediate) return Promise.resolve(immediate);
+
+    return new Promise(resolve => {
+        let settled = false;
+        let observer = null;
+        let pollTimer = null;
+        let timeoutTimer = null;
+
+        const finish = (result) => {
+            if (settled) return;
+            settled = true;
+            observer?.disconnect?.();
+            if (pollTimer) clearInterval(pollTimer);
+            if (timeoutTimer) clearTimeout(timeoutTimer);
+            resolve(result);
+        };
+
+        const check = () => {
+            const found = pickBestCandidate(selector);
+            if (found) finish(found);
+        };
+
+        if (typeof MutationObserver !== 'undefined' && document.documentElement) {
+            observer = new MutationObserver(check);
+            observer.observe(document.documentElement, { childList: true, subtree: true, attributes: true });
+        } else if (typeof setInterval === 'function') {
+            // No observer available (older host, or a test harness): fall back to polling.
+            pollTimer = setInterval(check, INPUT_POLL_INTERVAL);
+        }
+
+        timeoutTimer = setTimeout(() => finish(null), timeoutMs);
+
+        // A composer that appeared between the first scan and the observer being
+        // installed would otherwise be missed until the next mutation.
+        check();
+    });
 }
 
 function insertText(element, text, isContentEditable) {
@@ -422,8 +551,12 @@ async function pasteImages(inputEl, imageUrls) {
                 clipboardData: dt
             });
             inputEl.focus();
-            const accepted = inputEl.dispatchEvent(pasteEvent);
-            if (!accepted) throw new Error('Image paste event was cancelled.');
+            // dispatchEvent() returns false when a listener called preventDefault(),
+            // which is exactly what a site does when it consumes the pasted image.
+            // A true return means nothing handled the paste, so we cannot confirm it.
+            const notCancelled = inputEl.dispatchEvent(pasteEvent);
+            const consumed = notCancelled === false || pasteEvent.defaultPrevented === true;
+            if (!consumed) throw new Error('No paste handler detected.');
             pasted += 1;
             await delay(IMAGE_PASTE_DELAY);
         } catch (error) {
@@ -487,6 +620,10 @@ if (globalThis.R2AIAiPasterTest) {
         attemptPaste,
         pasteImages,
         collectImageUrls,
-        getPlatformInputTarget
+        getPlatformInputTarget,
+        waitForInput,
+        pickBestCandidate,
+        scoreCandidate,
+        detectLoginRequired
     });
 }

--- a/src/apiProviders.js
+++ b/src/apiProviders.js
@@ -1,0 +1,285 @@
+// Reddit to AI - Direct API provider definitions.
+//
+// This file is deliberately free of any chrome.* or fetch usage: it only turns a
+// (provider, key, model, prompt) tuple into a plain request description and turns a
+// raw JSON response back into `{ text, truncated }`. The service worker owns the
+// actual network call, the AbortController and the storage of keys. Keeping the
+// pure half separate is what lets the unit tests exercise every provider without
+// mocking an extension environment, and it guarantees no key ever reaches a code
+// path that logs or persists it here.
+
+(function attachApiProviders(globalObject) {
+  'use strict';
+
+  // Free-text model fields are prefilled with these. Providers ship new model IDs far
+  // faster than this extension ships releases, so the options page stores whatever the
+  // user types rather than constraining them to a hard-coded <select>.
+  const PROVIDERS = {
+    anthropic: {
+      id: 'anthropic',
+      label: 'Anthropic Claude',
+      defaultModel: 'claude-opus-5',
+      suggestedModels: ['claude-opus-5', 'claude-sonnet-5', 'claude-haiku-4-5'],
+      origin: 'https://api.anthropic.com'
+    },
+    openai: {
+      id: 'openai',
+      label: 'OpenAI',
+      defaultModel: 'gpt-5.2',
+      suggestedModels: ['gpt-5.2'],
+      origin: 'https://api.openai.com'
+    },
+    google: {
+      id: 'google',
+      label: 'Google Gemini',
+      defaultModel: 'gemini-2.5-flash',
+      suggestedModels: ['gemini-2.5-flash', 'gemini-2.5-pro'],
+      origin: 'https://generativelanguage.googleapis.com'
+    }
+  };
+
+  const PROVIDER_IDS = Object.keys(PROVIDERS);
+  const DEFAULT_MAX_TOKENS = 8192;
+  // Reasoning models can think for minutes before the first byte arrives, so the
+  // abort budget is deliberately far larger than a normal REST timeout.
+  const REQUEST_TIMEOUT_MS = 180000;
+  // Retryable statuses: 429 is rate limiting, 5xx/529 are transient upstream faults.
+  const RETRYABLE_STATUSES = new Set([408, 429, 500, 502, 503, 504, 529]);
+
+  function isSupportedProvider(provider) {
+    return Object.prototype.hasOwnProperty.call(PROVIDERS, provider);
+  }
+
+  function getProvider(provider) {
+    if (!isSupportedProvider(provider)) {
+      throw new Error(`Unknown direct API provider: ${provider}`);
+    }
+    return PROVIDERS[provider];
+  }
+
+  function resolveModel(provider, model) {
+    const trimmed = typeof model === 'string' ? model.trim() : '';
+    return trimmed || getProvider(provider).defaultModel;
+  }
+
+  /**
+   * Builds the raw HTTP request for a provider. Returns a plain object so the caller
+   * (and the tests) can inspect the URL, headers and body without a network stack.
+   *
+   * @param {string} provider one of 'anthropic' | 'openai' | 'google'
+   * @param {object} options
+   * @param {string} options.apiKey the user's key; only ever placed in a header
+   * @param {string} [options.model] free-text model id, falls back to the default
+   * @param {string} options.promptText the prompt to send
+   * @param {number} [options.maxTokens]
+   * @param {boolean} [options.legacyMaxTokens] OpenAI only: use the older
+   *        `max_tokens` field instead of `max_completion_tokens`
+   */
+  function buildRequest(provider, options = {}) {
+    const config = getProvider(provider);
+    const apiKey = typeof options.apiKey === 'string' ? options.apiKey.trim() : '';
+    if (!apiKey) throw new Error(`No API key configured for ${config.label}.`);
+
+    const promptText = typeof options.promptText === 'string' ? options.promptText : '';
+    if (!promptText.trim()) throw new Error('Prompt is empty.');
+
+    const model = resolveModel(provider, options.model);
+    const maxTokens = Number.isFinite(options.maxTokens) && options.maxTokens > 0
+      ? Math.floor(options.maxTokens)
+      : DEFAULT_MAX_TOKENS;
+
+    if (provider === 'anthropic') {
+      return {
+        url: 'https://api.anthropic.com/v1/messages',
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-api-key': apiKey,
+          'anthropic-version': '2023-06-01',
+          // Without this header the API rejects browser/extension origins outright.
+          'anthropic-dangerous-direct-browser-access': 'true'
+        },
+        body: {
+          model,
+          max_tokens: maxTokens,
+          messages: [{ role: 'user', content: promptText }]
+        }
+      };
+    }
+
+    if (provider === 'openai') {
+      const body = {
+        model,
+        messages: [{ role: 'user', content: promptText }]
+      };
+      // Newer models require `max_completion_tokens`; older ones only accept
+      // `max_tokens`. The caller retries once with the legacy field when the API
+      // complains about the parameter.
+      if (options.legacyMaxTokens) {
+        body.max_tokens = maxTokens;
+      } else {
+        body.max_completion_tokens = maxTokens;
+      }
+      return {
+        url: 'https://api.openai.com/v1/chat/completions',
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          authorization: `Bearer ${apiKey}`
+        },
+        body
+      };
+    }
+
+    // Google Gemini. The model id is part of the path, so it is encoded rather than
+    // interpolated raw: the field is free text typed by the user.
+    return {
+      url: `https://generativelanguage.googleapis.com/v1beta/models/${encodeURIComponent(model)}:generateContent`,
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-goog-api-key': apiKey
+      },
+      body: {
+        contents: [{ parts: [{ text: promptText }] }]
+      }
+    };
+  }
+
+  function parseAnthropicResponse(payload) {
+    const stopReason = payload?.stop_reason || null;
+    // The refusal stop reason must be checked *before* reading content: on a refusal
+    // the content array is not a usable answer.
+    if (stopReason === 'refusal') {
+      return {
+        text: '',
+        stopReason,
+        refused: true,
+        truncated: false
+      };
+    }
+    const blocks = Array.isArray(payload?.content) ? payload.content : [];
+    const text = blocks
+      .filter(block => block && block.type === 'text' && typeof block.text === 'string')
+      .map(block => block.text)
+      .join('');
+    return {
+      text,
+      stopReason,
+      refused: false,
+      truncated: stopReason === 'max_tokens'
+    };
+  }
+
+  function parseOpenAiResponse(payload) {
+    const choice = Array.isArray(payload?.choices) ? payload.choices[0] : null;
+    const text = typeof choice?.message?.content === 'string' ? choice.message.content : '';
+    const finishReason = choice?.finish_reason || null;
+    return {
+      text,
+      stopReason: finishReason,
+      refused: Boolean(choice?.message?.refusal),
+      truncated: finishReason === 'length'
+    };
+  }
+
+  function parseGoogleResponse(payload) {
+    const candidate = Array.isArray(payload?.candidates) ? payload.candidates[0] : null;
+    const parts = Array.isArray(candidate?.content?.parts) ? candidate.content.parts : [];
+    const text = parts
+      .filter(part => part && typeof part.text === 'string')
+      .map(part => part.text)
+      .join('');
+    const finishReason = candidate?.finishReason || null;
+    return {
+      text,
+      stopReason: finishReason,
+      refused: finishReason === 'SAFETY' || finishReason === 'PROHIBITED_CONTENT',
+      truncated: finishReason === 'MAX_TOKENS'
+    };
+  }
+
+  /**
+   * Normalises a successful (HTTP 2xx) provider payload into
+   * `{ text, stopReason, refused, truncated }`.
+   */
+  function parseResponse(provider, payload) {
+    getProvider(provider);
+    if (provider === 'anthropic') return parseAnthropicResponse(payload);
+    if (provider === 'openai') return parseOpenAiResponse(payload);
+    return parseGoogleResponse(payload);
+  }
+
+  function extractErrorMessage(provider, payload) {
+    if (!payload || typeof payload !== 'object') return '';
+    // All three providers nest the human-readable string under `error.message`,
+    // though Anthropic also carries a machine type alongside it.
+    if (payload.error && typeof payload.error === 'object') {
+      if (typeof payload.error.message === 'string') return payload.error.message;
+      if (typeof payload.error.status === 'string') return payload.error.status;
+    }
+    if (typeof payload.message === 'string') return payload.message;
+    return '';
+  }
+
+  function extractErrorType(provider, payload) {
+    if (!payload || typeof payload !== 'object') return '';
+    if (payload.error && typeof payload.error === 'object') {
+      if (typeof payload.error.type === 'string') return payload.error.type;
+      if (typeof payload.error.code === 'string') return payload.error.code;
+    }
+    return '';
+  }
+
+  /**
+   * Maps a failed HTTP response into `{ message, status, type, retryable }`.
+   * `retryable` drives the "try again in a moment" wording in the preview page.
+   */
+  function mapError(provider, status, payload) {
+    const config = getProvider(provider);
+    const message = extractErrorMessage(provider, payload);
+    const type = extractErrorType(provider, payload);
+    const numericStatus = Number.isFinite(status) ? status : 0;
+    const retryable = RETRYABLE_STATUSES.has(numericStatus);
+    return {
+      provider,
+      status: numericStatus,
+      type,
+      retryable,
+      message: message || `${config.label} request failed with HTTP ${numericStatus || 'error'}.`
+    };
+  }
+
+  /**
+   * True when an OpenAI 400 is specifically complaining about the token-limit
+   * parameter name, which is the signal to retry once with the legacy `max_tokens`.
+   */
+  function isMaxTokensParamError(provider, status, payload) {
+    if (provider !== 'openai' || status !== 400) return false;
+    const message = extractErrorMessage(provider, payload).toLowerCase();
+    const param = typeof payload?.error?.param === 'string' ? payload.error.param.toLowerCase() : '';
+    if (param === 'max_completion_tokens') return true;
+    return message.includes('max_completion_tokens');
+  }
+
+  const api = {
+    PROVIDERS,
+    PROVIDER_IDS,
+    DEFAULT_MAX_TOKENS,
+    REQUEST_TIMEOUT_MS,
+    RETRYABLE_STATUSES,
+    isSupportedProvider,
+    getProvider,
+    resolveModel,
+    buildRequest,
+    parseResponse,
+    mapError,
+    isMaxTokensParamError
+  };
+
+  globalObject.R2AIApiProviders = api;
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = api;
+  }
+})(typeof globalThis !== 'undefined' ? globalThis : this);

--- a/src/cl100k_base.js
+++ b/src/cl100k_base.js
@@ -183,40 +183,55 @@
 
   global.Tiktoken = Tiktoken;
 
-  if (typeof chrome !== 'undefined' && chrome.runtime && chrome.runtime.getURL) {
-    global.R2ATiktokenPromise = fetch(chrome.runtime.getURL('cl100k_base.json'))
-      .then(res => res.json())
-      .then(ranks => {
-        global.R2ATiktoken = new Tiktoken(ranks);
-        return global.R2ATiktoken;
-      })
-      .catch(err => {
-        console.error('Failed to load cl100k_base.json in extension:', err);
-      });
-  } else {
-    global.R2ATiktokenPromise = (async () => {
-      try {
-        const fs = await import('node:fs/promises');
-        let data;
-        try {
-          data = await fs.readFile('./cl100k_base.json', 'utf8');
-        } catch {
-          try {
-            data = await fs.readFile('./src/cl100k_base.json', 'utf8');
-          } catch {
-            try {
-              data = await fs.readFile('../src/cl100k_base.json', 'utf8');
-            } catch {
-              data = await fs.readFile('../cl100k_base.json', 'utf8');
-            }
-          }
-        }
-        const ranks = JSON.parse(data);
-        global.R2ATiktoken = new Tiktoken(ranks);
-        return global.R2ATiktoken;
-      } catch (err) {
-        console.error('Failed to load cl100k_base.json in Node.js:', err);
-      }
-    })();
+  // The cl100k_base.json rank table is ~1MB. Loading it eagerly in every context
+  // (service worker, popup, every AI tab, every Reddit tab) costs a fetch plus a
+  // full parse on startup, so the table is only loaded when a caller actually asks
+  // for exact token counts. Callers that do not wait fall back to length / 4.
+  let loadPromise = null;
+
+  async function loadRanksInExtension() {
+    const response = await fetch(chrome.runtime.getURL('cl100k_base.json'));
+    return response.json();
   }
+
+  async function loadRanksInNode() {
+    const fs = await import('node:fs/promises');
+    const candidates = [
+      './cl100k_base.json',
+      './src/cl100k_base.json',
+      '../src/cl100k_base.json',
+      '../cl100k_base.json'
+    ];
+    let lastError = null;
+    for (const candidate of candidates) {
+      try {
+        return JSON.parse(await fs.readFile(candidate, 'utf8'));
+      } catch (error) {
+        lastError = error;
+      }
+    }
+    throw lastError || new Error('cl100k_base.json not found');
+  }
+
+  // Starts (or joins) the lazy load. Resolves with the Tiktoken instance, or null
+  // when the rank table could not be loaded.
+  function ensureTiktoken() {
+    if (global.R2ATiktoken) return Promise.resolve(global.R2ATiktoken);
+    if (!loadPromise) {
+      const inExtension = typeof chrome !== 'undefined' && chrome.runtime && chrome.runtime.getURL;
+      loadPromise = (inExtension ? loadRanksInExtension() : loadRanksInNode())
+        .then(ranks => {
+          global.R2ATiktoken = new Tiktoken(ranks);
+          return global.R2ATiktoken;
+        })
+        .catch(err => {
+          console.error('Failed to load cl100k_base.json:', err);
+          loadPromise = null;
+          return null;
+        });
+    }
+    return loadPromise;
+  }
+
+  global.R2ATiktokenEnsure = ensureTiktoken;
 })(typeof globalThis !== 'undefined' ? globalThis : window);

--- a/src/floatingPanel.css
+++ b/src/floatingPanel.css
@@ -1,23 +1,44 @@
-/* Reddit to AI - Floating Panel Styles */
+/* Reddit to AI — Floating Progress Panel ("Ember" design system)
+   Injected into reddit.com — everything stays scoped to #redditSummarizerPanel / .rs- */
 
-/* ── Panel Container ──────────────────────────────────────── */
 #redditSummarizerPanel {
+    /* Ember tokens, scoped to the panel (no :root pollution on host page) */
+    --rs-surface: rgba(14, 14, 16, 0.96);
+    --rs-surface-2: #1a1a1e;
+    --rs-surface-3: #232329;
+    --rs-border: rgba(255, 255, 255, 0.07);
+    --rs-border-strong: rgba(255, 255, 255, 0.14);
+    --rs-text: #f4f4f5;
+    --rs-text-2: #a1a1aa;
+    --rs-text-3: #71717a;
+    --rs-accent: #ff4500;
+    --rs-accent-bright: #ff6a2b;
+    --rs-accent-grad: linear-gradient(135deg, #ff4500 0%, #ff6a2b 100%);
+    --rs-accent-soft: rgba(255, 69, 0, 0.12);
+    --rs-accent-border: rgba(255, 69, 0, 0.35);
+    --rs-accent-glow: rgba(255, 69, 0, 0.25);
+    --rs-success: #34d399;
+    --rs-warning: #fbbf24;
+    --rs-danger: #f87171;
+    --rs-info: #60a5fa;
+    --rs-ease: cubic-bezier(0.4, 0, 0.2, 1);
+
     position: fixed;
     top: 20px;
     right: 20px;
     width: 340px;
-    background: rgba(10, 10, 11, 0.96);
-    backdrop-filter: blur(24px);
-    -webkit-backdrop-filter: blur(24px);
-    color: #ffffff;
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background: var(--rs-surface);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+    color: var(--rs-text);
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
     font-size: 13px;
-    border-radius: 14px;
-    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 16px;
+    border: 1px solid var(--rs-border-strong);
     box-shadow:
-        0 8px 40px rgba(0, 0, 0, 0.6),
+        0 16px 48px rgba(0, 0, 0, 0.55),
         0 2px 12px rgba(0, 0, 0, 0.4),
-        0 0 0 1px rgba(255, 255, 255, 0.04) inset;
+        inset 0 1px 0 rgba(255, 255, 255, 0.05);
     z-index: 99999;
     display: flex;
     flex-direction: column;
@@ -37,10 +58,11 @@
 }
 
 /* ── Header ───────────────────────────────────────────────── */
+
 .rs-header {
     padding: 12px 14px;
-    background: rgba(255, 255, 255, 0.025);
-    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+    background: rgba(255, 255, 255, 0.02);
+    border-bottom: 1px solid var(--rs-border);
     cursor: move;
     display: flex;
     justify-content: space-between;
@@ -62,80 +84,61 @@
     border-radius: 50%;
     background: rgba(255, 255, 255, 0.15);
     flex-shrink: 0;
-    transition: background 0.3s, box-shadow 0.3s;
+    transition: background 0.3s var(--rs-ease), box-shadow 0.3s var(--rs-ease);
 }
 
 .rs-live-dot.active {
-    background: #FF4500;
-    box-shadow: 0 0 0 0 rgba(255, 69, 0, 0.6);
+    background: var(--rs-accent);
+    box-shadow: 0 0 0 0 rgba(255, 69, 0, 0.55);
     animation: rsLivePulse 1.4s ease-out infinite;
 }
 
 .rs-live-dot.error {
-    background: #ef4444;
+    background: var(--rs-danger);
     animation: none;
 }
 
 @keyframes rsLivePulse {
-    0% {
-        box-shadow: 0 0 0 0 rgba(255, 69, 0, 0.6);
-    }
-    70% {
-        box-shadow: 0 0 0 7px rgba(255, 69, 0, 0);
-    }
-    100% {
-        box-shadow: 0 0 0 0 rgba(255, 69, 0, 0);
-    }
+    0% { box-shadow: 0 0 0 0 rgba(255, 69, 0, 0.55); }
+    70% { box-shadow: 0 0 0 7px rgba(255, 69, 0, 0); }
+    100% { box-shadow: 0 0 0 0 rgba(255, 69, 0, 0); }
 }
 
 .rs-title {
-    font-weight: 600;
-    font-size: 14px;
-    color: #FF4500;
+    font-weight: 650;
+    font-size: 13px;
+    color: var(--rs-text);
     letter-spacing: -0.2px;
 }
 
-.rs-close-btn {
-    background: rgba(255, 255, 255, 0.05);
-    border: 1px solid rgba(255, 255, 255, 0.08);
+.rs-close-btn,
+.rs-local-summary-btn {
+    background: var(--rs-surface-2);
+    border: 1px solid var(--rs-border);
     width: 26px;
     height: 26px;
-    border-radius: 7px;
+    border-radius: 8px;
     cursor: pointer;
-    color: rgba(255, 255, 255, 0.35);
+    color: var(--rs-text-3);
     display: flex;
     align-items: center;
     justify-content: center;
-    transition: all 0.2s;
+    transition: color 0.15s var(--rs-ease), background 0.15s var(--rs-ease), border-color 0.15s var(--rs-ease);
     flex-shrink: 0;
 }
 
 .rs-close-btn:hover {
-    background: rgba(239, 68, 68, 0.12);
-    border-color: rgba(239, 68, 68, 0.3);
-    color: #ef4444;
+    background: rgba(248, 113, 113, 0.12);
+    border-color: rgba(248, 113, 113, 0.35);
+    color: var(--rs-danger);
 }
 
-.rs-local-summary-btn {
-    background: rgba(255, 255, 255, 0.05);
-    border: 1px solid rgba(255, 255, 255, 0.08);
-    width: 26px;
-    height: 26px;
-    border-radius: 7px;
-    cursor: pointer;
-    color: rgba(255, 255, 255, 0.35);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    transition: all 0.2s;
-    flex-shrink: 0;
-    margin-right: 6px;
-}
+.rs-local-summary-btn { margin-right: 6px; }
 
 .rs-local-summary-btn:hover:not(:disabled) {
-    background: rgba(59, 130, 246, 0.12);
-    border-color: rgba(59, 130, 246, 0.3);
-    color: #3b82f6;
+    background: rgba(96, 165, 250, 0.12);
+    border-color: rgba(96, 165, 250, 0.35);
+    color: var(--rs-info);
 }
 
 .rs-local-summary-btn:disabled {
@@ -144,6 +147,7 @@
 }
 
 /* ── Content ──────────────────────────────────────────────── */
+
 .rs-content {
     padding: 16px;
     overflow-y: auto;
@@ -154,6 +158,7 @@
 }
 
 /* ── Phase Track ──────────────────────────────────────────── */
+
 .rs-phase-track {
     display: flex;
     align-items: flex-start;
@@ -173,22 +178,22 @@
     width: 10px;
     height: 10px;
     border-radius: 50%;
-    background: rgba(255, 255, 255, 0.06);
-    border: 1.5px solid rgba(255, 255, 255, 0.12);
+    background: var(--rs-surface-3);
+    border: 1.5px solid var(--rs-border-strong);
     position: relative;
-    transition: background 0.25s, border-color 0.25s, box-shadow 0.25s;
+    transition: background 0.25s var(--rs-ease), border-color 0.25s var(--rs-ease), box-shadow 0.25s var(--rs-ease);
     display: flex;
     align-items: center;
     justify-content: center;
 }
 
-/* Checkmark for completed phases */
+/* Inner dot for completed phases */
 .rs-phase.completed .rs-phase-node::after {
     content: '';
     width: 4px;
     height: 4px;
     border-radius: 50%;
-    background: white;
+    background: #fff;
 }
 
 .rs-phase-pulse {
@@ -196,80 +201,70 @@
     position: absolute;
     inset: -5px;
     border-radius: 50%;
-    border: 1.5px solid rgba(255, 255, 255, 0.4);
+    border: 1.5px solid rgba(255, 106, 43, 0.5);
     animation: rsNodePulse 1.3s ease-out infinite;
 }
 
 @keyframes rsNodePulse {
-    0% {
-        transform: scale(0.8);
-        opacity: 0.8;
-    }
-    100% {
-        transform: scale(1.6);
-        opacity: 0;
-    }
+    0% { transform: scale(0.8); opacity: 0.8; }
+    100% { transform: scale(1.6); opacity: 0; }
 }
 
-/* Pending state */
 .rs-phase.pending .rs-phase-node {
-    background: rgba(255, 255, 255, 0.04);
-    border-color: rgba(255, 255, 255, 0.1);
+    background: var(--rs-surface-2);
+    border-color: var(--rs-border);
 }
 
-/* Active state */
 .rs-phase.active .rs-phase-node {
-    background: #ffffff;
-    border-color: #ffffff;
-    box-shadow: 0 0 10px rgba(255, 255, 255, 0.5), 0 0 20px rgba(255, 69, 0, 0.3);
+    background: #fff;
+    border-color: #fff;
+    box-shadow: 0 0 10px rgba(255, 255, 255, 0.45), 0 0 20px var(--rs-accent-glow);
 }
 
-.rs-phase.active .rs-phase-pulse {
-    display: block;
-}
+.rs-phase.active .rs-phase-pulse { display: block; }
 
-/* Completed state */
 .rs-phase.completed .rs-phase-node {
-    background: #FF4500;
-    border-color: #FF4500;
-    box-shadow: 0 0 8px rgba(255, 69, 0, 0.4);
+    background: var(--rs-accent);
+    border-color: var(--rs-accent);
+    box-shadow: 0 0 8px var(--rs-accent-glow);
 }
 
 .rs-phase-label {
     font-size: 9px;
     font-weight: 600;
-    letter-spacing: 0.6px;
+    letter-spacing: 0.06em;
     text-transform: uppercase;
-    color: rgba(255, 255, 255, 0.2);
-    transition: color 0.25s;
+    color: var(--rs-text-3);
+    opacity: 0.6;
+    transition: color 0.25s var(--rs-ease), opacity 0.25s var(--rs-ease);
     white-space: nowrap;
 }
 
 .rs-phase.active .rs-phase-label {
-    color: rgba(255, 255, 255, 0.85);
+    color: var(--rs-text);
+    opacity: 1;
 }
 
 .rs-phase.completed .rs-phase-label {
-    color: rgba(255, 69, 0, 0.65);
+    color: var(--rs-accent-bright);
+    opacity: 0.85;
 }
 
 /* Connector line between phase nodes */
 .rs-connector {
     flex: 1;
     height: 1.5px;
-    background: rgba(255, 255, 255, 0.07);
-    /* Vertically center on the node dot (10px node, 1.5px connector) */
+    background: var(--rs-border);
     margin-top: 4.25px;
-    /* Push down past the label area */
     margin-bottom: 15px;
     border-radius: 1px;
-    transition: background 0.3s;
+    transition: background 0.3s var(--rs-ease);
     position: relative;
     overflow: hidden;
 }
 
 .rs-connector.filled {
-    background: rgba(255, 69, 0, 0.45);
+    background: var(--rs-accent-border);
 }
 
 /* Sweep animation when a connector becomes filled */
@@ -287,6 +282,7 @@
 }
 
 /* ── Progress Area ────────────────────────────────────────── */
+
 .rs-progress-area {
     display: flex;
     flex-direction: column;
@@ -307,21 +303,21 @@
     font-variant-numeric: tabular-nums;
     letter-spacing: -1.5px;
     line-height: 1;
-    color: #ffffff;
-    font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', ui-monospace, monospace;
+    color: var(--rs-text);
+    font-family: ui-monospace, 'SF Mono', SFMono-Regular, Menlo, Consolas, monospace;
 }
 
 /* Context badge: "BATCH 6 / 11" or "312 COMMENTS" */
 .rs-context-badge {
     font-size: 10px;
     font-weight: 700;
-    letter-spacing: 0.8px;
+    letter-spacing: 0.07em;
     text-transform: uppercase;
     font-variant-numeric: tabular-nums;
-    color: #FF4500;
-    background: rgba(255, 69, 0, 0.1);
-    border: 1px solid rgba(255, 69, 0, 0.22);
-    border-radius: 20px;
+    color: var(--rs-accent-bright);
+    background: var(--rs-accent-soft);
+    border: 1px solid var(--rs-accent-border);
+    border-radius: 999px;
     padding: 3px 10px;
     white-space: nowrap;
 }
@@ -329,9 +325,9 @@
 /* Progress bar */
 .rs-progress-track {
     width: 100%;
-    height: 5px;
-    background: rgba(255, 255, 255, 0.06);
-    border-radius: 5px;
+    height: 6px;
+    background: var(--rs-surface-3);
+    border-radius: 999px;
     overflow: visible;
     position: relative;
 }
@@ -339,11 +335,27 @@
 .rs-progress-fill {
     height: 100%;
     width: 0%;
-    background: linear-gradient(90deg, #c43300 0%, #FF4500 60%, #ff7040 100%);
-    border-radius: 5px;
-    transition: width 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+    background: var(--rs-accent-grad);
+    border-radius: 999px;
+    transition: width 0.4s var(--rs-ease);
     position: relative;
-    box-shadow: 0 0 10px rgba(255, 69, 0, 0.55), 0 0 22px rgba(255, 69, 0, 0.18);
+    overflow: hidden;
+    box-shadow: 0 0 10px var(--rs-accent-glow);
+}
+
+/* Subtle sheen sweeping across the fill while loading */
+.rs-progress-fill::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(90deg, transparent 0%, rgba(255, 255, 255, 0.22) 50%, transparent 100%);
+    transform: translateX(-100%);
+    animation: rsSheen 1.8s var(--rs-ease) infinite;
+}
+
+@keyframes rsSheen {
+    0% { transform: translateX(-100%); }
+    60%, 100% { transform: translateX(100%); }
 }
 
 /* Glowing leading-edge cursor on the bar */
@@ -355,12 +367,11 @@
     transform: translateY(-50%);
     width: 3px;
     height: 10px;
-    background: #ffffff;
+    background: #fff;
     border-radius: 2px;
     box-shadow:
-        0 0 6px 2px rgba(255, 255, 255, 0.7),
-        0 0 14px 4px rgba(255, 69, 0, 0.5);
-    opacity: 1;
+        0 0 6px 2px rgba(255, 255, 255, 0.6),
+        0 0 14px 4px var(--rs-accent-glow);
 }
 
 /* Hide cursor when bar is at 0 or 100 */
@@ -369,28 +380,36 @@
     display: none;
 }
 
+.rs-progress-fill[style*="width: 100"]::before {
+    animation: none;
+}
+
 /* ── Status Message ───────────────────────────────────────── */
+
 .rs-status-msg {
     font-size: 12px;
-    color: rgba(255, 255, 255, 0.45);
+    color: var(--rs-text-2);
     margin: 0;
     line-height: 1.5;
     min-height: 18px;
 }
 
 /* ── Guidance ─────────────────────────────────────────────── */
+
 .rs-guidance {
     font-size: 11px;
-    color: rgba(245, 158, 11, 0.85);
+    color: rgba(251, 191, 36, 0.9);
     margin: 0;
     padding: 9px 12px;
-    background: rgba(245, 158, 11, 0.07);
-    border: 1px solid rgba(245, 158, 11, 0.15);
+    background: rgba(251, 191, 36, 0.07);
+    border: 1px solid rgba(251, 191, 36, 0.18);
+    border-left: 3px solid var(--rs-warning);
     border-radius: 8px;
     line-height: 1.5;
 }
 
 /* ── Summary Area ─────────────────────────────────────────── */
+
 .rs-summary-area {
     display: none;
     flex-direction: column;
@@ -412,29 +431,29 @@
     background: transparent;
     border: none;
     cursor: pointer;
-    color: rgba(255, 255, 255, 0.35);
+    color: var(--rs-text-3);
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 20px;
-    height: 20px;
-    border-radius: 4px;
-    transition: all 0.2s;
+    width: 22px;
+    height: 22px;
+    border-radius: 6px;
+    transition: color 0.15s var(--rs-ease), background 0.15s var(--rs-ease);
     padding: 0;
 }
 
 .rs-action-btn:hover {
     background: rgba(255, 255, 255, 0.08);
-    color: #ffffff;
+    color: var(--rs-text);
 }
 
 .rs-summary-area h4 {
     margin: 0;
     font-size: 10px;
-    font-weight: 700;
-    color: rgba(255, 255, 255, 0.25);
+    font-weight: 600;
+    color: var(--rs-text-3);
     text-transform: uppercase;
-    letter-spacing: 0.8px;
+    letter-spacing: 0.06em;
 }
 
 .rs-summary-area #rsSummaryText {
@@ -443,10 +462,10 @@
     overflow-y: auto;
     font-size: 13px;
     line-height: 1.65;
-    color: rgba(255, 255, 255, 0.85);
-    background: rgba(255, 255, 255, 0.03);
-    border: 1px solid rgba(255, 255, 255, 0.07);
-    border-radius: 10px;
+    color: var(--rs-text);
+    background: var(--rs-surface-2);
+    border: 1px solid var(--rs-border);
+    border-radius: 12px;
     word-wrap: break-word;
 }
 
@@ -458,12 +477,12 @@
 .rs-summary-area #rsSummaryText li { margin-bottom: 0.35em; }
 
 .rs-summary-area #rsSummaryText code {
-    background: rgba(255, 69, 0, 0.1);
+    background: var(--rs-accent-soft);
     padding: 2px 6px;
     border-radius: 4px;
-    font-family: 'SF Mono', Monaco, monospace;
+    font-family: ui-monospace, 'SF Mono', SFMono-Regular, Menlo, Consolas, monospace;
     font-size: 0.9em;
-    color: #FF4500;
+    color: var(--rs-accent-bright);
 }
 
 .rs-summary-area #rsSummaryText pre {
@@ -477,20 +496,20 @@
 .rs-summary-area #rsSummaryText pre code {
     background: transparent;
     padding: 0;
-    color: rgba(255, 255, 255, 0.8);
+    color: var(--rs-text-2);
 }
 
 .rs-summary-area #rsSummaryText blockquote {
     margin: 0 0 0.75em 0;
     padding: 10px 14px;
-    border-left: 3px solid #FF4500;
-    color: rgba(255, 255, 255, 0.5);
-    background: rgba(255, 69, 0, 0.05);
+    border-left: 3px solid var(--rs-accent);
+    color: var(--rs-text-2);
+    background: var(--rs-accent-soft);
     border-radius: 0 8px 8px 0;
     font-style: italic;
 }
 
-.rs-summary-area #rsSummaryText a { color: #FF4500; text-decoration: none; }
+.rs-summary-area #rsSummaryText a { color: var(--rs-accent-bright); text-decoration: none; }
 .rs-summary-area #rsSummaryText a:hover { text-decoration: underline; }
 
 .rs-summary-area #rsSummaryText h1,
@@ -499,7 +518,7 @@
 .rs-summary-area #rsSummaryText h4 {
     margin: 1em 0 0.5em 0;
     font-weight: 600;
-    color: #ffffff;
+    color: var(--rs-text);
     line-height: 1.3;
 }
 
@@ -509,9 +528,10 @@
 .rs-summary-area #rsSummaryText h4 { font-size: 1em; }
 
 /* ── Scrollbar ────────────────────────────────────────────── */
+
 .rs-content::-webkit-scrollbar,
 .rs-summary-area #rsSummaryText::-webkit-scrollbar {
-    width: 4px;
+    width: 6px;
 }
 
 .rs-content::-webkit-scrollbar-track,
@@ -521,11 +541,24 @@
 
 .rs-content::-webkit-scrollbar-thumb,
 .rs-summary-area #rsSummaryText::-webkit-scrollbar-thumb {
-    background: rgba(255, 255, 255, 0.08);
-    border-radius: 2px;
+    background: rgba(255, 255, 255, 0.12);
+    border-radius: 3px;
 }
 
 .rs-content::-webkit-scrollbar-thumb:hover,
 .rs-summary-area #rsSummaryText::-webkit-scrollbar-thumb:hover {
-    background: rgba(255, 255, 255, 0.15);
+    background: rgba(255, 255, 255, 0.22);
+}
+
+/* ── Reduced Motion ───────────────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+    #redditSummarizerPanel,
+    #redditSummarizerPanel *,
+    #redditSummarizerPanel *::before,
+    #redditSummarizerPanel *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+    }
 }

--- a/src/floatingPanel.js
+++ b/src/floatingPanel.js
@@ -18,19 +18,12 @@
       <div class="rs-live-dot" id="rsLiveDot"></div>
       <span class="rs-title">${t('panel_title') || 'Reddit to AI'}</span>
     </div>
-    <div style="display: flex; align-items: center;">
-      <button id="rsLocalSummaryBtn" class="rs-local-summary-btn" title="Summarize thread locally">
-        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-          <path d="m12 3-1.912 5.813a2 2 0 0 1-1.275 1.275L3 12l5.813 1.912a2 2 0 0 1 1.275 1.275L12 21l1.912-5.813a2 2 0 0 1 1.275-1.275L21 12l-5.813-1.912a2 2 0 0 1-1.275-1.275L12 3Z"/>
-        </svg>
-      </button>
-      <button id="rsCloseBtn" class="rs-close-btn" title="${t('close') || 'Close'}">
-        <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
-          <line x1="1" y1="1" x2="9" y2="9" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
-          <line x1="9" y1="1" x2="1" y2="9" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
-        </svg>
-      </button>
-    </div>
+    <button id="rsCloseBtn" class="rs-close-btn" title="${t('close') || 'Close'}">
+      <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
+        <line x1="1" y1="1" x2="9" y2="9" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+        <line x1="9" y1="1" x2="1" y2="9" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+      </svg>
+    </button>
   </div>
 
   <div class="rs-content">
@@ -75,28 +68,7 @@
     <!-- Guidance -->
     <p id="rsUserGuidance" class="rs-guidance" style="display:none"></p>
 
-    <!-- Summary (shown after completion) -->
-    <div class="rs-summary-area" id="rsSummaryArea">
-      <div class="rs-summary-header">
-        <h4>Summary</h4>
-        <div class="rs-summary-actions">
-          <button id="rsCopySummaryBtn" class="rs-action-btn" title="Copy to clipboard">
-            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
-              <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
-            </svg>
-          </button>
-          <button id="rsExportSummaryBtn" class="rs-action-btn" title="Export as Markdown text file">
-            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
-              <polyline points="7 10 12 15 17 10"></polyline>
-              <line x1="12" y1="15" x2="12" y2="3"></line>
-            </svg>
-          </button>
-        </div>
-      </div>
-      <div id="rsSummaryText"></div>
-    </div>
+
 
   </div>
 </div>
@@ -128,17 +100,36 @@
         const liveDot = shadow.getElementById('rsLiveDot');
         const pctEl = shadow.getElementById('rsPercentage');
         const badgeEl = shadow.getElementById('rsContextBadge');
-        const summaryArea = shadow.getElementById('rsSummaryArea');
-        const summaryText = shadow.getElementById('rsSummaryText');
-        const localSummaryBtn = shadow.getElementById('rsLocalSummaryBtn');
-        const copySummaryBtn = shadow.getElementById('rsCopySummaryBtn');
-        const exportSummaryBtn = shadow.getElementById('rsExportSummaryBtn');
+
 
         // ── Phase helpers ──────────────────────────────────
         const PHASES = ['fetch', 'parse', 'load', 'filter'];
         let committedPhaseIndex = 0; // monotonic — never goes backward
 
-        function detectPhase(message) {
+        // The service worker's phase vocabulary is richer than this four-step track,
+        // so several backend phases collapse onto the same visual node.
+        const PHASE_TO_TRACK = {
+            idle: 'fetch',
+            prepare: 'fetch',
+            fetch: 'fetch',
+            parse: 'parse',
+            load: 'load',
+            expand: 'load',
+            media: 'load',
+            filter: 'filter',
+            build: 'filter',
+            complete: 'filter'
+        };
+
+        function resolvePhase(data) {
+            const mapped = PHASE_TO_TRACK[data?.phase];
+            if (mapped) return mapped;
+            // Last-resort fallback for progress messages emitted by an older content
+            // script that predates the structured `phase` field.
+            return detectPhaseFromMessage(data?.message);
+        }
+
+        function detectPhaseFromMessage(message) {
             if (!message) return 'fetch';
             const msg = message.toLowerCase();
             // Order matters: more specific → less specific
@@ -149,7 +140,23 @@
             return 'fetch';
         }
 
-        function extractBatchInfo(message) {
+        function resolveBatchInfo(data) {
+            const batch = data?.batch;
+            if (batch && Number.isFinite(batch.current) && Number.isFinite(batch.total)) {
+                return { type: 'batch', current: batch.current, total: batch.total };
+            }
+            // The expand phase reports how many comments it has seen so far rather
+            // than an x-of-y counter.
+            if (batch && Number.isFinite(batch.count)) {
+                return { type: 'count', count: batch.count.toLocaleString() };
+            }
+            // Structured state is authoritative: once a phase is present, an absent
+            // `batch` means "no counter", not "go read the message".
+            if (data?.phase) return null;
+            return extractBatchInfoFromMessage(data?.message);
+        }
+
+        function extractBatchInfoFromMessage(message) {
             const batchMatch = message?.match(/batch\s+(\d+)\s*[\/\\]\s*(\d+)/i);
             if (batchMatch) {
                 return { type: 'batch', current: parseInt(batchMatch[1]), total: parseInt(batchMatch[2]) };
@@ -199,71 +206,7 @@
             }
         }
 
-        function formatLocalSummaryHtml(text) {
-            if (!text) return '';
-            let escaped = text
-                .replace(/&/g, '&amp;')
-                .replace(/</g, '&lt;')
-                .replace(/>/g, '&gt;');
-            escaped = escaped.replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>');
-            const lines = escaped.split('\n');
-            let inList = false;
-            const htmlParts = [];
-            
-            for (const line of lines) {
-                const trimmed = line.trim();
-                if (trimmed.startsWith('- ') || trimmed.startsWith('* ')) {
-                    const content = trimmed.substring(2);
-                    if (!inList) {
-                        inList = true;
-                        htmlParts.push('<ul>');
-                    }
-                    htmlParts.push('<li>' + content + '</li>');
-                } else {
-                    if (inList) {
-                        inList = false;
-                        htmlParts.push('</ul>');
-                    }
-                    if (trimmed) {
-                        htmlParts.push('<p>' + trimmed + '</p>');
-                    }
-                }
-            }
-            if (inList) {
-                htmlParts.push('</ul>');
-            }
-            return htmlParts.join('');
-        }
 
-        // ── Local Summary button ───────────────────────────
-        if (localSummaryBtn) {
-            chrome.runtime.sendMessage({ action: 'checkLocalAiCapability' }, (response) => {
-                if (chrome.runtime.lastError || !response || !response.available) {
-                    localSummaryBtn.style.display = 'none';
-                } else {
-                    localSummaryBtn.style.display = 'flex';
-                }
-            });
-
-            localSummaryBtn.addEventListener('click', (e) => {
-                e.preventDefault();
-                e.stopPropagation();
-
-                if (summaryArea) summaryArea.style.display = 'none';
-                if (summaryText) summaryText.textContent = '';
-
-                chrome.runtime.sendMessage({
-                    action: 'scrapeReddit',
-                    tabId: null,
-                    localSummarize: true,
-                    filters: {}
-                }, (_response) => {
-                    if (chrome.runtime.lastError) {
-                        console.error('Local summary scrape start error:', chrome.runtime.lastError.message);
-                    }
-                });
-            });
-        }
 
         // ── Close button ───────────────────────────────────
         if (closeBtn && panel) {
@@ -274,42 +217,7 @@
             });
         }
 
-        // ── Copy Summary button ────────────────────────────
-        if (copySummaryBtn && summaryText) {
-            copySummaryBtn.addEventListener('click', (e) => {
-                e.preventDefault();
-                e.stopPropagation();
-                const textToCopy = summaryText.innerText || summaryText.textContent || '';
-                if (!textToCopy) return;
-                navigator.clipboard.writeText(textToCopy)
-                    .then(() => {
-                        console.log('Summary copied to clipboard!');
-                    })
-                    .catch(err => {
-                        console.error('Failed to copy summary:', err);
-                    });
-            });
-        }
 
-        // ── Export Summary button ──────────────────────────
-        if (exportSummaryBtn && summaryText) {
-            exportSummaryBtn.addEventListener('click', (e) => {
-                e.preventDefault();
-                e.stopPropagation();
-                const textToExport = summaryText.innerText || summaryText.textContent || '';
-                if (!textToExport) return;
-                
-                const blob = new Blob([textToExport], { type: 'text/markdown;charset=utf-8;' });
-                const url = URL.createObjectURL(blob);
-                const a = document.createElement('a');
-                a.href = url;
-                a.download = `reddit-local-summary-${Date.now()}.md`;
-                document.body.appendChild(a);
-                a.click();
-                document.body.removeChild(a);
-                URL.revokeObjectURL(url);
-            });
-        }
 
         // ── Draggable ──────────────────────────────────────
         if (header && panel) {
@@ -317,10 +225,7 @@
             let offsetX = 0, offsetY = 0;
 
             header.addEventListener('mousedown', (e) => {
-                if (
-                    e.target === closeBtn || closeBtn?.contains(e.target) ||
-                    e.target === localSummaryBtn || localSummaryBtn?.contains(e.target)
-                ) return;
+                if (e.target === closeBtn || closeBtn?.contains(e.target)) return;
                 isDragging = true;
                 offsetX = e.clientX - panel.offsetLeft;
                 offsetY = e.clientY - panel.offsetTop;
@@ -367,7 +272,7 @@
                 if ((data.percentage || 0) <= 5 && committedPhaseIndex > 0) {
                     resetPhases();
                 }
-                updatePhaseUI(detectPhase(message));
+                updatePhaseUI(resolvePhase(data));
             } else if (data.error) {
                 resetPhases();
             }
@@ -388,7 +293,7 @@
                 }
 
                 // Context badge
-                const info = extractBatchInfo(message);
+                const info = resolveBatchInfo(data);
                 if (badgeEl) {
                     if (info?.type === 'batch') {
                         badgeEl.textContent = `BATCH ${info.current} / ${info.total}`;
@@ -424,20 +329,14 @@
                 }
             }
 
-            // Local Summary Area
-            if (data.summary !== undefined && data.summary !== null) {
-                if (summaryArea) summaryArea.style.display = 'flex';
-                if (summaryText) {
-                    summaryText.innerHTML = formatLocalSummaryHtml(data.summary);
-                    // scroll to bottom
-                    summaryText.scrollTop = summaryText.scrollHeight;
-                }
-            } else {
-                if (summaryArea) summaryArea.style.display = 'none';
-            }
 
-            // Auto-hide on completion
-            if (!data.isActive && !data.error && message?.includes('sent')) {
+
+            // Auto-hide on completion. `status`/`phase` are authoritative; the message
+            // check only covers states produced before those fields existed.
+            const finished = data.status
+                ? data.status === 'complete'
+                : (data.phase === 'complete' || message?.includes('sent'));
+            if (!data.isActive && !data.error && finished) {
                 setTimeout(() => {
                     if (panel.style.display !== 'none') {
                         panel.style.display = 'none';

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "__MSG_extName__",
   "short_name": "R2AI",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "__MSG_extDescription__",
   "author": "Alp Yalay",
   "homepage_url": "https://github.com/KhazP/Reddit-to-AI",
@@ -12,8 +12,8 @@
     "scripting",
     "storage",
     "notifications",
-    "tabs",
-    "unlimitedStorage"
+    "unlimitedStorage",
+    "contextMenus"
   ],
   "host_permissions": [
     "*://*.reddit.com/*",
@@ -26,7 +26,10 @@
     "https://claude.ai/*",
     "https://aistudio.google.com/*",
     "https://chat.deepseek.com/*",
-    "https://*.groq.com/*"
+    "https://*.groq.com/*",
+    "https://api.anthropic.com/*",
+    "https://api.openai.com/*",
+    "https://generativelanguage.googleapis.com/*"
   ],
   "content_scripts": [
     {
@@ -68,6 +71,15 @@
   },
   "background": {
     "service_worker": "service_worker.js"
+  },
+  "commands": {
+    "scrape-current-thread": {
+      "suggested_key": {
+        "default": "Alt+Shift+S",
+        "mac": "Alt+Shift+S"
+      },
+      "description": "__MSG_command_scrape_current_thread__"
+    }
   },
   "icons": {
     "16": "images/icon16.png",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "__MSG_extName__",
   "short_name": "R2AI",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "__MSG_extDescription__",
   "author": "Alp Yalay",
   "homepage_url": "https://github.com/KhazP/Reddit-to-AI",

--- a/src/options.css
+++ b/src/options.css
@@ -1,29 +1,58 @@
-/* Reddit to AI - Options Page Styles */
+/* Reddit to AI — Options Page ("Ember" design system) */
 
 :root {
-  --bg-primary: #0d0d0d;
-  --bg-secondary: rgba(26, 26, 27, 0.6);
-  /* Semi-transparent */
-  --bg-card: rgba(39, 39, 42, 0.4);
-  /* Glass transparency */
-  --bg-glass: rgba(255, 255, 255, 0.03);
-  --bg-glass-hover: rgba(255, 255, 255, 0.06);
-  --border-color: rgba(255, 255, 255, 0.08);
-  /* More subtle */
-  --text-primary: #ffffff;
-  --text-secondary: #a0a0a0;
-  --text-muted: #6b6b6b;
-  --accent: #FF4500;
-  --accent-hover: #ff5722;
-  --accent-glow: rgba(255, 69, 0, 0.3);
-  --success: #10b981;
-  --error: #ef4444;
-  --radius-sm: 8px;
-  --radius-md: 12px;
-  --radius-lg: 16px;
-  --shadow: 0 4px 24px rgba(0, 0, 0, 0.4);
-  --blur: 12px;
-  --transition: color 0.2s cubic-bezier(0.4, 0, 0.2, 1), background 0.2s cubic-bezier(0.4, 0, 0.2, 1), border-color 0.2s cubic-bezier(0.4, 0, 0.2, 1), box-shadow 0.2s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  /* Surfaces */
+  --bg: #09090b;
+  --surface: #121214;
+  --surface-2: #1a1a1e;
+  --surface-3: #232329;
+  --overlay: rgba(9, 9, 11, 0.72);
+
+  /* Borders */
+  --border: rgba(255, 255, 255, 0.07);
+  --border-strong: rgba(255, 255, 255, 0.14);
+
+  /* Text */
+  --text: #f4f4f5;
+  --text-2: #a1a1aa;
+  --text-3: #71717a;
+
+  /* Brand */
+  --accent: #ff4500;
+  --accent-bright: #ff6a2b;
+  --accent-grad: linear-gradient(135deg, #ff4500 0%, #ff6a2b 100%);
+  --accent-soft: rgba(255, 69, 0, 0.12);
+  --accent-border: rgba(255, 69, 0, 0.35);
+  --accent-glow: rgba(255, 69, 0, 0.25);
+
+  /* Status */
+  --success: #34d399;
+  --warning: #fbbf24;
+  --danger: #f87171;
+  --info: #60a5fa;
+
+  /* Shape */
+  --r-sm: 8px;
+  --r-md: 12px;
+  --r-lg: 16px;
+  --r-full: 999px;
+
+  /* Elevation */
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+  --shadow-md: 0 8px 24px rgba(0, 0, 0, 0.45);
+  --shadow-lg: 0 16px 48px rgba(0, 0, 0, 0.55);
+
+  /* Motion */
+  --ease: cubic-bezier(0.4, 0, 0.2, 1);
+  --t-fast: 0.15s;
+  --t-med: 0.25s;
+
+  /* Focus */
+  --ring: 0 0 0 3px rgba(255, 69, 0, 0.28);
+
+  /* Legacy aliases (used by a few inline styles / older markup) */
+  --border-color: rgba(255, 255, 255, 0.07);
+  --transition: all 0.15s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 * {
@@ -33,264 +62,410 @@
 }
 
 body {
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-  background: var(--bg-primary);
-  background-image:
-    radial-gradient(ellipse 80% 50% at 50% -20%, rgba(255, 69, 0, 0.08) 0%, transparent 50%),
-    radial-gradient(ellipse 60% 40% at 100% 100%, rgba(255, 69, 0, 0.03) 0%, transparent 40%);
-  color: var(--text-primary);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  background: var(--bg);
+  background-image: radial-gradient(900px 320px at 50% -120px, rgba(255, 69, 0, 0.06), transparent);
+  color: var(--text);
   font-size: 14px;
   line-height: 1.5;
   min-height: 100vh;
+  -webkit-font-smoothing: antialiased;
 }
+
+button, input, select, textarea { font-family: inherit; }
+
+:focus { outline: none; }
+:focus-visible { outline: none; box-shadow: var(--ring); }
+
+::-webkit-scrollbar { width: 8px; height: 8px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: rgba(255, 255, 255, 0.12); border-radius: 4px; }
+::-webkit-scrollbar-thumb:hover { background: rgba(255, 255, 255, 0.22); }
 
 .options-container {
-  max-width: 1200px;
+  max-width: 1060px;
   margin: 0 auto;
-  padding: 24px 32px;
+  padding: 28px 24px 40px;
   display: flex;
   flex-direction: column;
-  gap: 24px;
-  min-height: 100vh;
+  gap: 22px;
 }
 
-/* Header */
+/* ── Header ───────────────────────────────────────────────── */
+
 .header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding-bottom: 24px;
-  border-bottom: 1px solid var(--border-color);
+  gap: 16px;
 }
 
-.logo {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-}
+.header-left { display: flex; align-items: center; }
+.header-right { display: flex; align-items: center; gap: 10px; }
 
-.logo-icon {
-  filter: drop-shadow(0 2px 8px var(--accent-glow));
-}
+.logo { display: flex; align-items: center; gap: 12px; }
 
-.logo-text {
-  display: flex;
-  flex-direction: column;
-}
+.logo-icon { filter: drop-shadow(0 2px 8px var(--accent-glow)); }
+
+.logo-text { display: flex; flex-direction: column; }
 
 .logo-title {
-  font-size: 24px;
+  font-size: 19px;
   font-weight: 700;
-  letter-spacing: -0.5px;
+  letter-spacing: -0.4px;
+  line-height: 1.2;
 }
 
-.logo-reddit {
-  color: var(--accent);
-}
-
-.logo-to {
-  color: var(--text-muted);
-  margin: 0 2px;
-  font-weight: 400;
-}
-
-.logo-ai {
-  color: var(--text-primary);
-}
+.logo-reddit { color: var(--accent); }
+.logo-to { color: var(--text-3); margin: 0 2px; font-weight: 400; }
+.logo-ai { color: var(--text); }
 
 .logo-subtitle {
-  font-size: 12px;
-  color: var(--text-secondary);
-  font-weight: 500;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-3);
   text-transform: uppercase;
-  letter-spacing: 1px;
+  letter-spacing: 0.06em;
 }
 
-/* Save Toast */
+/* Save status toast */
 .save-toast {
-  padding: 8px 16px;
-  background: var(--success);
-  color: white;
-  border-radius: var(--radius-sm);
-  font-size: 13px;
-  font-weight: 500;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 14px;
+  background: rgba(52, 211, 153, 0.1);
+  border: 1px solid rgba(52, 211, 153, 0.3);
+  border-left: 3px solid var(--success);
+  border-radius: var(--r-sm);
+  color: var(--success);
+  font-size: 12px;
+  font-weight: 600;
   opacity: 0;
-  transform: translateY(-10px);
-  transition: var(--transition);
+  transform: translateY(-4px);
+  transition: opacity var(--t-med) var(--ease), transform var(--t-med) var(--ease);
+  pointer-events: none;
 }
 
-.save-toast.visible {
-  opacity: 1;
-  transform: translateY(0);
-}
+.save-toast.visible { opacity: 1; transform: translateY(0); }
 
-/* Main Content - Sidebar Layout */
+/* ── Layout ───────────────────────────────────────────────── */
+
 .main-content {
-  display: flex;
-  gap: 32px;
-  margin-top: 24px;
-  align-items: flex-start;
+  display: grid;
+  grid-template-columns: 216px 1fr;
+  gap: 22px;
+  align-items: start;
 }
 
 .sidebar-nav {
-  width: 240px;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 2px;
   position: sticky;
   top: 24px;
-  flex-shrink: 0;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  padding: 6px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
 }
 
 .nav-item {
   display: flex;
   align-items: center;
-  gap: 12px;
-  padding: 12px 16px;
-  background: transparent;
-  border: 1px solid transparent;
-  border-radius: var(--radius-md);
-  color: var(--text-secondary);
-  font-size: 14px;
+  gap: 10px;
+  width: 100%;
+  padding: 9px 12px;
+  background: none;
+  border: none;
+  border-radius: var(--r-sm);
+  color: var(--text-2);
+  font-size: 13px;
   font-weight: 500;
-  cursor: pointer;
   text-align: left;
-  transition: var(--transition);
+  cursor: pointer;
+  position: relative;
+  transition: color var(--t-fast) var(--ease), background var(--t-fast) var(--ease);
 }
 
-.nav-item:hover {
-  background: var(--bg-glass-hover);
-  color: var(--text-primary);
-}
+.nav-item:hover { color: var(--text); background: var(--surface-2); }
 
 .nav-item.active {
-  background: rgba(255, 69, 0, 0.1);
-  border-color: var(--accent);
-  color: var(--accent);
+  color: var(--accent-bright);
+  background: var(--accent-soft);
   font-weight: 600;
-  box-shadow: 0 0 12px var(--accent-glow);
 }
+
+.nav-item.active::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 8px;
+  bottom: 8px;
+  width: 2px;
+  border-radius: 1px;
+  background: var(--accent);
+}
+
+.nav-icon { flex-shrink: 0; opacity: 0.85; }
+.nav-label { min-width: 0; }
 
 .settings-pane {
   display: none;
   flex-direction: column;
-  gap: 20px;
-  flex: 1;
+  gap: 18px;
   min-width: 0;
 }
 
 .settings-pane.active {
   display: flex;
+  animation: paneIn 0.25s var(--ease) backwards;
 }
 
-@media (max-width: 768px) {
-  .main-content {
-    flex-direction: column;
-    gap: 24px;
-  }
-  .sidebar-nav {
-    width: 100%;
-    flex-direction: row;
-    overflow-x: auto;
-    padding-bottom: 8px;
-    position: static;
-  }
-  .nav-item {
-    white-space: nowrap;
-    padding: 8px 14px;
-    font-size: 13px;
-  }
+@keyframes paneIn {
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: translateY(0); }
 }
 
-/* Cards */
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(-4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Cards ────────────────────────────────────────────────── */
+
 .card {
-  background: rgba(21, 21, 23, 0.95);
-  border: 1px solid rgba(255, 255, 255, 0.11);
-  border-radius: var(--radius-md);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03), var(--shadow-sm);
   overflow: hidden;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
-  box-shadow: 0 14px 36px rgba(0, 0, 0, 0.24);
-}
-
-.card:hover {
-  border-color: rgba(255, 255, 255, 0.15);
-  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05), 0 0 20px rgba(255, 69, 0, 0.05);
-}
-
-.card-large {
-  flex: 1;
 }
 
 .card-header {
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 18px 24px;
-  background: rgba(255, 255, 255, 0.035);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 15px 20px;
+  border-bottom: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.015);
 }
 
-.card-icon {
-  color: var(--accent);
-}
+.card-icon { color: var(--accent-bright); flex-shrink: 0; }
 
 .card-title {
-  font-size: 16px;
+  font-size: 14px;
   font-weight: 600;
-  color: var(--text-primary);
+  color: var(--text);
+  letter-spacing: -0.1px;
+  flex: 1;
 }
 
 .card-content {
-  padding: 24px;
-}
-
-/* Form Elements */
-.form-group {
+  padding: 18px 20px;
   display: flex;
   flex-direction: column;
-  gap: 10px;
-  margin-bottom: 18px;
+  gap: 18px;
 }
 
-.form-group:last-child {
-  margin-bottom: 0;
+/* ── Forms ────────────────────────────────────────────────── */
+
+.form-group { display: flex; flex-direction: column; gap: 8px; }
+
+.form-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
 }
+
+.form-row .form-row-grow { flex: 1; min-width: 0; }
+.form-row .form-row-grow-2 { flex: 2; min-width: 0; }
+.form-row select.select-input { min-width: 110px; }
 
 .form-label {
-  font-size: 12px;
-  font-weight: 700;
-  color: var(--text-secondary);
-  letter-spacing: 0.02em;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-3);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
 }
 
 .form-hint {
   font-size: 12px;
-  color: var(--text-muted);
+  color: var(--text-3);
   line-height: 1.5;
 }
 
+.form-hint-lead { margin-bottom: 4px; }
+
 .form-hint code {
-  background: var(--bg-glass);
-  padding: 2px 6px;
+  background: var(--accent-soft);
+  color: var(--accent-bright);
+  padding: 1px 6px;
   border-radius: 4px;
-  font-family: 'SF Mono', Monaco, monospace;
-  color: var(--accent);
+  font-family: ui-monospace, 'SF Mono', SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 11px;
 }
 
-/* Platform Grid */
-.platform-grid {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 10px;
+.select-input,
+.search-input,
+.ai-dropdown {
+  width: 100%;
+  height: 38px;
+  padding: 0 12px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  color: var(--text);
+  font-size: 13px;
+  transition: border-color var(--t-fast) var(--ease), box-shadow var(--t-fast) var(--ease);
 }
 
-.platform-option {
-  display: block;
+.select-input:hover,
+.search-input:hover,
+.ai-dropdown:hover { border-color: var(--border-strong); }
+
+.select-input:focus,
+.search-input:focus,
+.ai-dropdown:focus { border-color: var(--accent); box-shadow: var(--ring); }
+
+.select-input option { background: var(--surface-2); color: var(--text); }
+
+.search-input::placeholder { color: var(--text-3); }
+
+.textarea {
+  width: 100%;
+  padding: 12px 14px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  color: var(--text);
+  font-size: 13px;
+  font-family: ui-monospace, 'SF Mono', SFMono-Regular, Menlo, Consolas, monospace;
+  line-height: 1.55;
+  resize: vertical;
+  min-height: 140px;
+  transition: border-color var(--t-fast) var(--ease), box-shadow var(--t-fast) var(--ease);
+}
+
+.textarea::placeholder { color: var(--text-3); font-family: inherit; }
+.textarea:focus { border-color: var(--accent); box-shadow: var(--ring); }
+.textarea.readonly { color: var(--text-2); background: var(--surface); cursor: default; }
+
+.number-input {
+  width: 80px;
+  height: 34px;
+  padding: 0 10px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  color: var(--text);
+  font-size: 13px;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  transition: border-color var(--t-fast) var(--ease), box-shadow var(--t-fast) var(--ease);
+}
+
+.number-input:focus { border-color: var(--accent); box-shadow: var(--ring); }
+
+.inline-input-row { display: flex; align-items: center; gap: 10px; }
+.inline-label { font-size: 13px; color: var(--text-2); }
+
+.template-label-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.btn-reset {
+  background: none;
+  border: none;
+  color: var(--accent-bright);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 4px 6px;
+  border-radius: 6px;
+  transition: background var(--t-fast) var(--ease);
+}
+
+.btn-reset:hover { background: var(--accent-soft); }
+
+/* ── Sliders ──────────────────────────────────────────────── */
+
+.slider-row { display: flex; align-items: center; gap: 14px; }
+
+.slider {
+  flex: 1;
+  height: 5px;
+  -webkit-appearance: none;
+  appearance: none;
+  background: var(--surface-3);
+  border-radius: var(--r-full);
   cursor: pointer;
 }
 
+.slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #fff;
+  border: none;
+  box-shadow: 0 0 0 4px var(--accent-soft), var(--shadow-sm);
+  cursor: pointer;
+  transition: box-shadow var(--t-fast) var(--ease), transform var(--t-fast) var(--ease);
+}
+
+.slider::-webkit-slider-thumb:hover {
+  box-shadow: 0 0 0 6px var(--accent-soft), var(--shadow-sm);
+  transform: scale(1.05);
+}
+
+.slider::-moz-range-thumb {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #fff;
+  border: none;
+  box-shadow: 0 0 0 4px var(--accent-soft), var(--shadow-sm);
+  cursor: pointer;
+}
+
+.slider-value {
+  width: 74px;
+  height: 34px;
+  padding: 0 10px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  color: var(--text);
+  font-size: 13px;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  transition: border-color var(--t-fast) var(--ease), box-shadow var(--t-fast) var(--ease);
+}
+
+.slider-value:focus { border-color: var(--accent); box-shadow: var(--ring); }
+
+/* ── Platform Grid ────────────────────────────────────────── */
+
+.platform-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(112px, 1fr));
+  gap: 8px;
+}
+
+.platform-option { cursor: pointer; position: relative; }
+
 .platform-option input {
-  display: none;
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
 }
 
 .platform-box {
@@ -298,962 +473,549 @@ body {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 10px;
-  padding: 24px 16px;
-  background: var(--bg-card);
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-md);
-  transition: var(--transition);
+  gap: 8px;
+  padding: 16px 8px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  transition: background var(--t-fast) var(--ease), border-color var(--t-fast) var(--ease);
 }
 
-.platform-box:hover {
-  border-color: rgba(255, 255, 255, 0.3);
-  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.3);
-}
-
-.platform-option input:checked+.platform-box {
-  border-color: var(--accent);
-  background: linear-gradient(135deg, rgba(255, 69, 0, 0.2) 0%, rgba(39, 39, 42, 0.6) 100%);
-  box-shadow: 0 0 24px var(--accent-glow), 0 8px 20px rgba(0, 0, 0, 0.3);
-}
+.platform-box:hover { background: var(--surface-3); border-color: var(--border-strong); }
 
 .platform-icon {
-  width: 36px;
-  height: 36px;
-  object-fit: contain;
-  filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.3));
-  transition: var(--transition);
-}
-
-.platform-box:hover .platform-icon {
-  transform: scale(1.1);
-}
-
-.platform-svg {
   width: 32px;
   height: 32px;
+  opacity: 0.85;
+  transition: opacity var(--t-fast) var(--ease);
 }
+
+.platform-box:hover .platform-icon { opacity: 1; }
 
 .platform-text {
-  font-size: 13px;
+  font-size: 12px;
   font-weight: 500;
-  color: var(--text-secondary);
+  color: var(--text-2);
+  transition: color var(--t-fast) var(--ease);
 }
 
-.platform-option input:checked+.platform-box .platform-text {
-  color: var(--text-primary);
+.platform-option input:checked + .platform-box {
+  background: var(--accent-soft);
+  border-color: var(--accent-border);
 }
 
-/* Depth Options */
+.platform-option input:checked + .platform-box .platform-icon { opacity: 1; }
+
+.platform-option input:checked + .platform-box .platform-text {
+  color: var(--accent-bright);
+  font-weight: 600;
+}
+
+.platform-option input:focus-visible + .platform-box { box-shadow: var(--ring); }
+
+/* ── Depth Options ────────────────────────────────────────── */
+
 .depth-options {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 10px;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 8px;
 }
 
-.depth-option {
-  display: block;
-  cursor: pointer;
-}
+.depth-option { cursor: pointer; position: relative; }
 
 .depth-option input {
-  display: none;
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
 }
 
 .depth-box {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 4px;
-  padding: 16px 10px;
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-md);
-  transition: var(--transition);
+  gap: 3px;
+  padding: 14px 8px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
   text-align: center;
+  transition: background var(--t-fast) var(--ease), border-color var(--t-fast) var(--ease);
 }
 
-.depth-box:hover {
-  border-color: var(--accent);
-}
-
-.depth-option input:checked+.depth-box {
-  border-color: var(--accent);
-  background: linear-gradient(135deg, rgba(255, 69, 0, 0.15) 0%, var(--bg-secondary) 100%);
-  box-shadow: 0 0 16px var(--accent-glow);
-}
+.depth-box:hover { background: var(--surface-3); border-color: var(--border-strong); }
 
 .depth-level {
-  font-size: 24px;
+  font-size: 20px;
   font-weight: 700;
-  color: var(--accent);
+  color: var(--text-2);
+  font-variant-numeric: tabular-nums;
+  transition: color var(--t-fast) var(--ease);
 }
 
-.depth-name {
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--text-primary);
+.depth-name { font-size: 12px; font-weight: 600; color: var(--text); }
+.depth-desc { font-size: 11px; color: var(--text-3); }
+
+.depth-option input:checked + .depth-box {
+  background: var(--accent-soft);
+  border-color: var(--accent-border);
 }
 
-.depth-desc {
-  font-size: 10px;
-  color: var(--text-muted);
-}
+.depth-option input:checked + .depth-box .depth-level { color: var(--accent-bright); }
 
-/* Toggle Switch */
-.toggle-row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  cursor: pointer;
-  padding: 8px 0;
-}
+.depth-option input:focus-visible + .depth-box { box-shadow: var(--ring); }
 
-.toggle-info {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
+/* ── Author Pills ─────────────────────────────────────────── */
 
-.toggle-label {
-  font-size: 14px;
-  font-weight: 500;
-  color: var(--text-primary);
-}
+.author-options { display: flex; gap: 8px; flex-wrap: wrap; }
 
-.toggle-hint {
-  font-size: 12px;
-  color: var(--text-muted);
-}
+.author-option { cursor: pointer; position: relative; }
 
-.toggle-switch {
-  position: relative;
-  width: 48px;
-  height: 26px;
-  flex-shrink: 0;
-}
-
-.toggle-switch input {
+.author-option input {
+  position: absolute;
   opacity: 0;
   width: 0;
   height: 0;
 }
 
-.toggle-slider {
-  position: absolute;
-  cursor: pointer;
-  inset: 0;
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-color);
-  border-radius: 26px;
-  transition: var(--transition);
-}
-
-.toggle-slider::before {
-  content: '';
-  position: absolute;
-  height: 20px;
-  width: 20px;
-  left: 2px;
-  bottom: 2px;
-  background: var(--text-secondary);
-  border-radius: 50%;
-  transition: var(--transition);
-}
-
-.toggle-switch input:checked+.toggle-slider {
-  background: var(--accent);
-  border-color: var(--accent);
-  box-shadow: 0 0 12px var(--accent-glow);
-}
-
-.toggle-switch input:focus+.toggle-slider {
-  box-shadow: 0 0 0 3px var(--accent-glow);
-}
-
-.toggle-switch input:checked+.toggle-slider::before {
-  transform: translateX(22px);
-  background: white;
-}
-
-/* Textarea */
-.textarea {
-  width: 100%;
-  min-height: 180px;
-  padding: 14px;
-  background: var(--bg-card);
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-md);
-  color: var(--text-primary);
-  font-family: 'SF Mono', Monaco, 'Courier New', monospace;
-  font-size: 13px;
-  line-height: 1.6;
-  resize: vertical;
-  transition: var(--transition);
-}
-
-.textarea:focus {
-  outline: none;
-  border-color: var(--accent);
-  box-shadow: 0 0 0 3px var(--accent-glow);
-  background: rgba(39, 39, 42, 0.6);
-}
-
-.textarea::placeholder {
-  color: var(--text-muted);
-}
-
-/* Preset Selector */
-.preset-selector {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  margin-bottom: 8px;
-}
-
-.preset-pill {
-  display: flex;
+.author-pill {
+  display: inline-flex;
   align-items: center;
-  gap: 6px;
-  padding: 10px 14px;
-  background: var(--bg-glass);
-  border: 1px solid var(--border-color);
-  border-radius: 20px;
-  cursor: pointer;
-  transition: var(--transition);
-  font-size: 13px;
-  color: var(--text-primary);
-  font-family: inherit;
-}
-
-.preset-pill:hover {
-  border-color: rgba(255, 255, 255, 0.3);
-  background: var(--bg-glass-hover);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2), 0 0 10px var(--accent-glow);
-}
-
-.preset-pill.selected {
-  background: linear-gradient(135deg, rgba(255, 69, 0, 0.2) 0%, var(--bg-secondary) 100%);
-  border-color: var(--accent);
-  box-shadow: 0 0 16px var(--accent-glow);
-}
-
-.preset-pill-icon {
-  font-size: 15px;
-}
-
-.preset-pill-name {
-  font-weight: 500;
-  color: var(--text-primary);
-}
-
-.preset-pill-desc {
-  color: var(--text-muted);
-  font-size: 11px;
-  display: none;
-}
-
-@media (min-width: 700px) {
-  .preset-pill-desc {
-    display: inline;
-  }
-}
-
-/* Template Label Row */
-.template-label-row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-
-.btn-reset {
-  background: none;
-  border: none;
-  color: var(--accent);
+  height: 30px;
+  padding: 0 14px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--r-full);
+  color: var(--text-2);
   font-size: 12px;
-  cursor: pointer;
-  padding: 4px 8px;
-  border-radius: 4px;
-  transition: var(--transition);
-  font-family: inherit;
-  display: none;
+  font-weight: 500;
+  transition: color var(--t-fast) var(--ease), background var(--t-fast) var(--ease), border-color var(--t-fast) var(--ease);
 }
 
-.btn-reset:hover {
-  background: rgba(255, 69, 0, 0.1);
-  text-decoration: underline;
+.author-pill:hover { background: var(--surface-3); border-color: var(--border-strong); color: var(--text); }
+
+.author-option input:checked + .author-pill {
+  background: var(--accent-soft);
+  border-color: var(--accent-border);
+  color: var(--accent-bright);
+  font-weight: 600;
 }
 
-/* Read-only textarea for non-custom presets */
-.textarea.readonly {
-  opacity: 0.7;
-  cursor: default;
-  background: var(--bg-glass);
-}
+.author-option input:focus-visible + .author-pill { box-shadow: var(--ring); }
 
-/* Radio Group */
-.radio-group {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
+/* ── Radio Group ──────────────────────────────────────────── */
+
+.radio-group { display: flex; flex-direction: column; gap: 8px; }
 
 .radio-option {
   display: flex;
   align-items: center;
   gap: 12px;
-  padding: 12px;
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-md);
+  padding: 12px 14px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
   cursor: pointer;
-  transition: var(--transition);
+  transition: background var(--t-fast) var(--ease), border-color var(--t-fast) var(--ease);
 }
 
-.radio-option:hover {
-  border-color: rgba(255, 255, 255, 0.2);
-}
-
-.radio-option input {
-  display: none;
-}
-
-.radio-option input:checked~.radio-content .radio-label {
-  color: var(--accent);
-}
+.radio-option:hover { background: var(--surface-3); border-color: var(--border-strong); }
 
 .radio-option:has(input:checked) {
-  border-color: var(--accent);
-  background: linear-gradient(135deg, rgba(255, 69, 0, 0.1) 0%, var(--bg-secondary) 100%);
+  background: var(--accent-soft);
+  border-color: var(--accent-border);
 }
 
-.radio-content {
+.radio-option input { accent-color: var(--accent); width: 15px; height: 15px; flex-shrink: 0; }
+
+.radio-content { display: flex; flex-direction: column; gap: 1px; min-width: 0; }
+
+.radio-label { font-size: 13px; font-weight: 500; color: var(--text); }
+
+.radio-option input:checked ~ .radio-content .radio-label { color: var(--accent-bright); font-weight: 600; }
+
+.radio-hint { font-size: 12px; color: var(--text-3); }
+
+/* ── Toggles ──────────────────────────────────────────────── */
+
+.toggle-group { display: flex; flex-direction: column; gap: 4px; }
+
+.toggle-row {
   display: flex;
-  flex-direction: column;
-  gap: 2px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 8px 0;
+  cursor: pointer;
 }
 
-.radio-label {
-  font-size: 14px;
-  font-weight: 500;
-  color: var(--text-primary);
-  transition: var(--transition);
+.toggle-info { display: flex; flex-direction: column; gap: 1px; min-width: 0; }
+
+.toggle-label { font-size: 13px; font-weight: 500; color: var(--text); }
+.toggle-hint { font-size: 12px; color: var(--text-3); }
+
+.toggle-switch { position: relative; width: 40px; height: 22px; flex-shrink: 0; }
+
+.toggle-switch input { opacity: 0; width: 0; height: 0; }
+
+.toggle-slider {
+  position: absolute;
+  cursor: pointer;
+  inset: 0;
+  background: var(--surface-3);
+  border: 1px solid var(--border);
+  border-radius: var(--r-full);
+  transition: background var(--t-fast) var(--ease), border-color var(--t-fast) var(--ease);
 }
 
-.radio-hint {
+.toggle-slider::before {
+  content: '';
+  position: absolute;
+  height: 16px;
+  width: 16px;
+  left: 2px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: var(--text-2);
+  border-radius: 50%;
+  transition: transform var(--t-fast) var(--ease), background var(--t-fast) var(--ease);
+  box-shadow: var(--shadow-sm);
+}
+
+.toggle-switch input:focus-visible + .toggle-slider { box-shadow: var(--ring); }
+.toggle-switch input:focus + .toggle-slider { box-shadow: none; }
+.toggle-switch input:focus-visible + .toggle-slider { box-shadow: var(--ring); }
+
+.toggle-switch input:checked + .toggle-slider {
+  background: var(--accent-grad);
+  border-color: transparent;
+}
+
+.toggle-switch input:checked + .toggle-slider::before {
+  transform: translate(18px, -50%);
+  background: #fff;
+}
+
+/* ── Buttons ──────────────────────────────────────────────── */
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 9px 16px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--surface-2);
+  color: var(--text);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--t-fast) var(--ease), border-color var(--t-fast) var(--ease), filter var(--t-fast) var(--ease), transform var(--t-fast) var(--ease);
+}
+
+.btn:hover { background: var(--surface-3); border-color: var(--border-strong); }
+.btn:active { transform: scale(0.98); }
+
+.btn.primary {
+  background: var(--accent-grad);
+  border-color: transparent;
+  color: #fff;
+  box-shadow: var(--shadow-sm), inset 0 1px 0 rgba(255, 255, 255, 0.18);
+}
+
+.btn.primary:hover {
+  filter: brightness(1.08);
+  box-shadow: 0 4px 20px var(--accent-glow), inset 0 1px 0 rgba(255, 255, 255, 0.18);
+}
+
+.btn-nowrap { white-space: nowrap; }
+
+.btn-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 8px 14px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  color: var(--text-2);
   font-size: 12px;
-  color: var(--text-muted);
-}
-
-/* Content Filters Styles */
-.slider-row {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-}
-
-.slider {
-  flex: 1;
-  -webkit-appearance: none;
-  appearance: none;
-  height: 6px;
-  background: var(--bg-secondary);
-  border-radius: 3px;
-  outline: none;
+  font-weight: 600;
   cursor: pointer;
+  transition: color var(--t-fast) var(--ease), background var(--t-fast) var(--ease), border-color var(--t-fast) var(--ease);
 }
 
-.slider::-webkit-slider-thumb {
-  -webkit-appearance: none;
-  appearance: none;
-  width: 18px;
-  height: 18px;
-  border-radius: 50%;
-  background: var(--accent);
-  cursor: pointer;
-  transition: var(--transition);
-  box-shadow: 0 2px 8px var(--accent-glow);
+.btn-action:hover:not(:disabled) {
+  color: var(--text);
+  background: var(--surface-3);
+  border-color: var(--border-strong);
 }
 
-.slider::-webkit-slider-thumb:hover {
-  transform: scale(1.1);
+.btn-action:disabled { opacity: 0.45; cursor: not-allowed; }
+
+.btn-action.btn-export { border-color: var(--accent-border); color: var(--accent-bright); }
+.btn-action.btn-export:hover:not(:disabled) { background: var(--accent-soft); color: var(--accent-bright); }
+
+.btn-action.btn-danger-outline { border-color: rgba(248, 113, 113, 0.35); color: var(--danger); }
+.btn-action.btn-danger-outline:hover:not(:disabled) {
+  background: rgba(248, 113, 113, 0.1);
+  border-color: rgba(248, 113, 113, 0.5);
+  color: var(--danger);
 }
 
-.slider::-moz-range-thumb {
-  width: 18px;
-  height: 18px;
-  border-radius: 50%;
-  background: var(--accent);
-  cursor: pointer;
-  border: none;
-}
+.btn-accent-outline { border-color: var(--accent-border); color: var(--accent-bright); }
+.btn-accent-outline:hover:not(:disabled) { background: var(--accent-soft); color: var(--accent-bright); }
 
-.slider-value {
-  width: 60px;
-  padding: 8px 10px;
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-sm);
-  color: var(--text-primary);
-  font-size: 14px;
-  font-family: inherit;
-  text-align: center;
-}
+.btn-icon-only { padding: 8px; }
+.btn-icon-only svg { display: block; }
 
-.slider-value:focus {
-  outline: none;
-  border-color: var(--accent);
-}
+/* ── Preset Selector Pills ────────────────────────────────── */
 
-.inline-input-row {
-  display: flex;
-  align-items: center;
+.preset-selector {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
   gap: 8px;
 }
 
-.inline-label {
-  font-size: 13px;
-  color: var(--text-secondary);
-}
-
-.number-input {
-  width: 70px;
-  padding: 8px 10px;
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-sm);
-  color: var(--text-primary);
-  font-size: 14px;
-  font-family: inherit;
-  text-align: center;
-}
-
-.number-input:focus {
-  outline: none;
-  border-color: var(--accent);
-}
-
-.author-options {
-  display: flex;
-  gap: 8px;
-  flex-wrap: wrap;
-}
-
-.author-option {
-  cursor: pointer;
-}
-
-.author-option input {
-  display: none;
-}
-
-.author-pill {
-  display: inline-block;
-  padding: 8px 16px;
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-color);
-  border-radius: 20px;
-  font-size: 13px;
-  color: var(--text-secondary);
-  transition: var(--transition);
-}
-
-.author-pill:hover {
-  border-color: var(--accent);
-}
-
-.author-option input:checked+.author-pill {
-  background: linear-gradient(135deg, rgba(255, 69, 0, 0.2) 0%, var(--bg-secondary) 100%);
-  border-color: var(--accent);
-  color: var(--text-primary);
-  box-shadow: 0 0 12px var(--accent-glow);
-}
-
-.saved-preset-list {
+.preset-pill {
   display: flex;
   flex-direction: column;
-  gap: 10px;
-  max-height: 280px;
-  overflow-y: auto;
+  align-items: flex-start;
+  gap: 3px;
+  padding: 12px 14px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  color: var(--text-2);
+  font-size: 13px;
+  text-align: left;
+  cursor: pointer;
+  transition: background var(--t-fast) var(--ease), border-color var(--t-fast) var(--ease);
 }
+
+.preset-pill:hover { background: var(--surface-3); border-color: var(--border-strong); }
+
+.preset-pill.selected {
+  background: var(--accent-soft);
+  border-color: var(--accent-border);
+}
+
+.preset-pill-icon { font-size: 16px; line-height: 1; }
+
+.preset-pill-name { font-size: 13px; font-weight: 600; color: var(--text); }
+
+.preset-pill.selected .preset-pill-name { color: var(--accent-bright); }
+
+.preset-pill-desc { font-size: 11px; color: var(--text-3); line-height: 1.4; }
+
+/* ── Saved Presets ────────────────────────────────────────── */
+
+.saved-preset-list { display: flex; flex-direction: column; gap: 8px; }
 
 .saved-preset-item {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  padding: 12px;
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-md);
+  padding: 11px 14px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  transition: border-color var(--t-fast) var(--ease);
 }
+
+.saved-preset-item:hover { border-color: var(--border-strong); }
 
 .saved-preset-main {
   display: flex;
+  flex-direction: column;
+  gap: 2px;
   min-width: 0;
   flex: 1;
-  flex-direction: column;
-  gap: 3px;
 }
 
 .saved-preset-main strong {
-  overflow: hidden;
-  color: var(--text-primary);
   font-size: 13px;
-  font-weight: 600;
+  color: var(--text);
+  overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .saved-preset-main span {
-  color: var(--text-muted);
-  font-size: 12px;
+  font-size: 11px;
+  color: var(--text-3);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.saved-preset-controls,
-.saved-preset-actions {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  flex-wrap: wrap;
-}
+.saved-preset-controls { display: flex; gap: 6px; flex-shrink: 0; }
 
-.toggle-group {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding-top: 8px;
-  margin-top: 8px;
-  border-top: 1px solid var(--border-color);
-}
+.saved-preset-actions { margin-top: 4px; }
 
-/* Footer */
-.footer {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding-top: 16px;
-  border-top: 1px solid var(--border-color);
-}
-
-.footer-text {
-  font-size: 12px;
-  color: var(--text-muted);
-}
-
-/* Scrollbar */
-::-webkit-scrollbar {
-  width: 6px;
-  height: 6px;
-}
-
-::-webkit-scrollbar-track {
-  background: transparent;
-  border-radius: 3px;
-}
-
-::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.15);
-  border-radius: 3px;
-  transition: background 0.2s ease;
-}
-
-::-webkit-scrollbar-thumb:hover {
-  background: var(--accent);
-}
-
-/* Animations */
-@keyframes slideUpFade {
-  0% {
-    opacity: 0;
-    transform: translateY(20px) scale(0.98);
-  }
-
-  100% {
-    opacity: 1;
-    transform: translateY(0) scale(1);
-  }
-}
-
-.card {
-  animation: slideUpFade 0.6s cubic-bezier(0.2, 0.8, 0.2, 1) backwards;
-}
-
-.card:nth-child(1) {
-  animation-delay: 0.1s;
-}
-
-.card:nth-child(2) {
-  animation-delay: 0.15s;
-}
-
-.card:nth-child(3) {
-  animation-delay: 0.2s;
-}
-
-.card:nth-child(4) {
-  animation-delay: 0.25s;
-}
-
-/* Animation class for dynamic history items */
-.history-item.entering {
-  animation: slideUpFade 0.5s cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
-}
-
-/* =====================
-   Scrape History Card
-   ===================== */
-
-/* Card header with count badge */
-#historyCard .card-header {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-}
+/* ── History ──────────────────────────────────────────────── */
 
 .history-count {
-  margin-left: auto;
-  font-size: 12px;
-  color: var(--text-muted);
-  background: var(--bg-secondary);
-  padding: 4px 10px;
-  border-radius: 12px;
-}
-
-/* History list container */
-.history-list {
-  max-height: 400px;
-  overflow-y: auto;
-  margin: 12px 0;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-
-/* Empty state */
-.history-empty {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 12px;
-  padding: 40px 20px;
-  color: var(--text-muted);
-  font-size: 13px;
-}
-
-/* History item card */
-.history-item {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 14px;
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-md);
-  transition: var(--transition);
-}
-
-.history-item:hover {
-  border-color: rgba(255, 255, 255, 0.2);
-}
-
-/* Item title row */
-.history-item-header {
-  display: flex;
-  align-items: flex-start;
-  gap: 10px;
-}
-
-.history-item-title {
-  flex: 1;
-  font-size: 14px;
-  font-weight: 500;
-  color: var(--text-primary);
-  line-height: 1.4;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
-}
-
-/* Meta info row: subreddit, time, comments */
-.history-item-meta {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  font-size: 12px;
-  color: var(--text-muted);
-  flex-wrap: wrap;
-}
-
-.history-item-subreddit {
-  color: var(--accent);
-  font-weight: 500;
-}
-
-.history-item-dot {
-  font-size: 8px;
-  color: var(--text-muted);
-}
-
-/* Action buttons row */
-.history-item-actions {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding-top: 8px;
-  border-top: 1px solid var(--border-color);
-}
-
-/* AI Platform dropdown for resend */
-.ai-dropdown {
-  padding: 6px 10px;
-  background: var(--bg-glass);
-  border: 1px solid var(--border-color);
-  border-radius: 6px;
-  color: var(--text-primary);
-  font-size: 12px;
-  font-family: inherit;
-  cursor: pointer;
-  transition: var(--transition);
-  flex: 1;
-  max-width: 140px;
-}
-
-.ai-dropdown:hover {
-  border-color: rgba(255, 255, 255, 0.2);
-}
-
-.ai-dropdown:focus {
-  outline: none;
-  border-color: var(--accent);
-}
-
-/* Action buttons */
-.btn-action {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 6px;
-  padding: 6px 12px;
-  background: transparent;
-  border: 1px solid var(--border-color);
-  border-radius: 6px;
-  color: var(--text-secondary);
-  font-size: 12px;
-  font-family: inherit;
-  cursor: pointer;
-  transition: var(--transition);
-}
-
-.btn-action:hover {
-  border-color: rgba(255, 255, 255, 0.25);
-  color: var(--text-primary);
-  background: var(--bg-glass);
-}
-
-.btn-action:disabled {
-  opacity: 0.4;
-  cursor: not-allowed;
-}
-
-.btn-action.btn-resend {
-  background: linear-gradient(135deg, rgba(255, 69, 0, 0.15) 0%, transparent 100%);
-  border-color: var(--accent);
-  color: var(--accent);
-}
-
-.btn-action.btn-resend:hover {
-  background: linear-gradient(135deg, rgba(255, 69, 0, 0.25) 0%, rgba(255, 69, 0, 0.1) 100%);
-  color: var(--text-primary);
-}
-
-.btn-action.btn-danger-outline {
-  border-color: rgba(239, 68, 68, 0.4);
-  color: var(--error);
-}
-
-.btn-action.btn-danger-outline:hover:not(:disabled) {
-  background: rgba(239, 68, 68, 0.1);
-  border-color: var(--error);
-}
-
-.btn-action.btn-export {
-  border-color: rgba(16, 185, 129, 0.4);
-  color: var(--success);
-}
-
-.btn-action.btn-export:hover {
-  background: rgba(16, 185, 129, 0.1);
-  border-color: var(--success);
-}
-
-/* Bottom actions row */
-.history-actions {
-  display: flex;
-  justify-content: flex-end;
-  padding-top: 12px;
-  border-top: 1px solid var(--border-color);
-  margin-top: 4px;
-}
-
-.history-status {
-  min-height: 18px;
-  margin: 8px 0 0;
-  color: var(--text-secondary);
-  font-size: 13px;
-}
-
-.history-status.error {
-  color: var(--error);
-}
-
-.history-status.success {
-  color: var(--success);
-}
-
-/* Icon-only button variant */
-.btn-icon-only {
-  padding: 6px;
-  min-width: auto;
-}
-
-.btn-icon-only svg {
-  width: 14px;
-  height: 14px;
-}
-/* Upgrade controls */
-.select-input,
-.search-input {
-  width: 100%;
-  padding: 9px 12px;
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-sm);
-  color: var(--text-primary);
-  font-size: 13px;
-  font-family: inherit;
-  transition: var(--transition);
-}
-
-.select-input:focus,
-.search-input:focus {
-  outline: none;
-  border-color: var(--accent);
-  box-shadow: 0 0 0 3px var(--accent-glow);
-}
-
-.select-input option {
-  background: #1a1a1b;
-  color: var(--text-primary);
-}
-
-.search-input::placeholder {
-  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-3);
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--r-full);
+  padding: 3px 10px;
+  font-variant-numeric: tabular-nums;
 }
 
 .history-filter-grid {
   display: grid;
-  grid-template-columns: 1.5fr 1fr 1fr;
+  grid-template-columns: 1fr 1fr;
   gap: 8px;
-  margin-top: 12px;
 }
 
-.history-min-comments {
-  width: 100%;
-  text-align: left;
-}
+.history-filter-grid .search-input { grid-column: 1 / -1; }
+
+.history-min-comments { width: 100%; text-align: left; }
 
 .history-tools {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 10px;
-  margin-top: 12px;
-  padding: 10px 12px;
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-md);
-  background: var(--bg-glass);
+  gap: 12px;
 }
 
-.history-tool-label {
-  color: var(--text-muted);
-  font-size: 12px;
+.history-tool-label { font-size: 12px; color: var(--text-3); }
+
+.history-status { font-size: 12px; color: var(--text-3); min-height: 16px; }
+.history-status.success { color: var(--success); }
+.history-status.error { color: var(--danger); }
+
+.history-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-height: 480px;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.history-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  padding: 36px 16px;
+  color: var(--text-3);
+  font-size: 13px;
+  text-align: center;
+  border: 1px dashed var(--border-strong);
+  border-radius: var(--r-md);
+}
+
+.history-item {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px 14px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  transition: border-color var(--t-fast) var(--ease);
+}
+
+.history-item:hover { border-color: var(--border-strong); }
+
+.history-item.entering { animation: paneIn 0.25s var(--ease) backwards; }
+
+.history-item-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
 }
 
 .history-item-title-row {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   gap: 8px;
-  flex: 1;
+  min-width: 0;
 }
 
-.history-badges {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  flex-wrap: wrap;
+.history-item-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--accent);
+  flex-shrink: 0;
 }
+
+.history-item-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.history-item-subreddit { color: var(--accent-bright); font-weight: 600; }
+
+.history-item-meta {
+  font-size: 11px;
+  color: var(--text-3);
+  font-variant-numeric: tabular-nums;
+}
+
+.history-badges { display: flex; gap: 5px; flex-wrap: wrap; }
 
 .history-badge {
-  display: inline-flex;
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--text-2);
+  background: var(--surface-3);
+  border: 1px solid var(--border);
+  border-radius: var(--r-full);
+  padding: 2px 8px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.history-item-actions {
+  display: flex;
+  gap: 6px;
   align-items: center;
-  gap: 4px;
-  padding: 3px 7px;
-  border: 1px solid var(--border-color);
-  border-radius: 999px;
-  color: var(--text-muted);
-  font-size: 11px;
-  background: var(--bg-glass);
+  flex-shrink: 0;
+}
+
+.history-icon-btn { padding: 6px; }
+
+.history-icon-btn.active {
+  color: var(--accent-bright);
+  border-color: var(--accent-border);
+  background: var(--accent-soft);
 }
 
 .history-compare-label {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  color: var(--text-secondary);
-  font-size: 12px;
+  font-size: 11px;
+  color: var(--text-3);
   cursor: pointer;
-  margin-right: auto;
 }
 
-.history-compare-label input {
-  accent-color: var(--accent);
-}
+.history-compare-label input { accent-color: var(--accent); }
 
-.history-icon-btn {
-  min-width: 30px;
-  padding: 6px 8px;
-}
+.history-actions { display: flex; gap: 8px; flex-wrap: wrap; }
 
-.history-icon-btn.active {
-  border-color: var(--accent);
-  color: var(--accent);
-  background: rgba(255, 69, 0, 0.1);
-}
+/* ── Custom Origins / Subreddit Rules ─────────────────────── */
 
-@media (max-width: 700px) {
-  .history-filter-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .history-tools,
-  .history-item-actions,
-  .saved-preset-item,
-  .saved-preset-controls,
-  .saved-preset-actions {
-    align-items: stretch;
-    flex-direction: column;
-  }
-
-  .ai-dropdown {
-    max-width: none;
-  }
-}
-
-/* Custom Origins list styling */
 .custom-origins-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -1263,69 +1025,136 @@ body {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 8px 12px;
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-md);
+  gap: 12px;
+  padding: 10px 14px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  transition: border-color var(--t-fast) var(--ease);
 }
+
+.custom-origin-item:hover { border-color: var(--border-strong); }
 
 .custom-origin-text {
   font-size: 13px;
-  color: var(--text-primary);
-  font-family: 'SF Mono', Monaco, 'Courier New', monospace;
+  color: var(--text);
+  font-family: ui-monospace, 'SF Mono', SFMono-Regular, Menlo, Consolas, monospace;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-/* Button general styles */
-.btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 6px;
-  padding: 8px 16px;
-  border-radius: var(--radius-sm);
-  font-size: 13px;
-  font-weight: 500;
-  font-family: inherit;
-  cursor: pointer;
-  transition: var(--transition);
-  border: 1px solid var(--border-color);
-  background: var(--bg-glass);
-  color: var(--text-primary);
-}
-
-.btn:hover {
-  background: var(--bg-glass-hover);
-  border-color: rgba(255, 255, 255, 0.2);
-}
-
-.btn.primary {
-  background: var(--accent);
-  border-color: var(--accent);
-  color: #ffffff;
-  box-shadow: 0 2px 8px var(--accent-glow);
-}
-
-.btn.primary:hover {
-  background: var(--accent-hover);
-  border-color: var(--accent-hover);
-  box-shadow: 0 4px 12px var(--accent-glow);
-}
+/* ── Tester Result ────────────────────────────────────────── */
 
 .tester-result {
-  margin-top: 8px;
-  border-radius: var(--radius-sm);
-  background: rgba(255, 255, 255, 0.02);
-  border: 1px solid var(--border-color);
+  padding: 12px 14px;
+  border-radius: var(--r-sm);
+  background: var(--surface-2);
+  border: 1px solid var(--border);
   font-size: 13px;
-  padding: 12px;
-  color: var(--text-primary);
-  animation: fadeIn 0.2s ease-out;
+  color: var(--text-2);
+  display: none;
+  animation: fadeIn 0.2s var(--ease) forwards;
 }
 
-@keyframes fadeIn {
-  from { opacity: 0; transform: translateY(-4px); }
-  to { opacity: 1; transform: translateY(0); }
+/* ── Footer ───────────────────────────────────────────────── */
+
+.footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding-top: 18px;
+  border-top: 1px solid var(--border);
 }
+
+.footer-text { font-size: 12px; color: var(--text-3); }
+
+/* ── Responsive ───────────────────────────────────────────── */
+
+@media (max-width: 760px) {
+  .main-content { grid-template-columns: 1fr; }
+
+  .sidebar-nav {
+    position: static;
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+
+  .nav-item { width: auto; flex: 1; justify-content: center; }
+  .nav-item.active::before { display: none; }
+}
+
+/* ── Reduced Motion ───────────────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+
+
+/* ── Direct API keys ──────────────────────────────────────── */
+.api-warning {
+  margin: 0 0 4px;
+  font-size: 12.5px;
+  line-height: 1.55;
+  color: var(--text-2);
+  background: rgba(251, 191, 36, 0.08);
+  border: 1px solid rgba(251, 191, 36, 0.3);
+  border-radius: 8px;
+  padding: 10px 12px;
+}
+
+.api-provider-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.api-provider-row {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 14px 16px;
+  background: var(--surface-2);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.api-provider-name {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.api-key-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.api-key-row .search-input {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.api-provider-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.api-key-status {
+  min-height: 18px;
+  font-size: 12.5px;
+  color: var(--text-2);
+}
+
+.api-key-status.error { color: var(--danger); }
+.api-key-status.success { color: var(--success); }

--- a/src/options.html
+++ b/src/options.html
@@ -35,11 +35,66 @@
         <!-- Main Content - Sidebar Layout -->
         <main class="main-content">
             <nav class="sidebar-nav">
-                <button type="button" class="nav-item active" data-target="sectionAi">🌐 AI Assistant</button>
-                <button type="button" class="nav-item" data-target="sectionPresets">📝 Prompt Presets</button>
-                <button type="button" class="nav-item" data-target="sectionScraping">⚙️ Scraping & Filters</button>
-                <button type="button" class="nav-item" data-target="sectionMappings">🔀 Subreddit Mappings</button>
-                <button type="button" class="nav-item" data-target="sectionCustom">🔌 Custom WebUIs</button>
+                <button type="button" class="nav-item active" data-target="sectionAi">
+                    <svg class="nav-icon" width="16" height="16" viewBox="0 0 24 24" fill="none"
+                        stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                        aria-hidden="true">
+                        <circle cx="12" cy="12" r="10"></circle>
+                        <line x1="2" y1="12" x2="22" y2="12"></line>
+                        <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"></path>
+                    </svg>
+                    <span class="nav-label">AI Assistant</span>
+                </button>
+                <button type="button" class="nav-item" data-target="sectionPresets">
+                    <svg class="nav-icon" width="16" height="16" viewBox="0 0 24 24" fill="none"
+                        stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                        aria-hidden="true">
+                        <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+                        <polyline points="14 2 14 8 20 8"></polyline>
+                        <line x1="16" y1="13" x2="8" y2="13"></line>
+                        <line x1="16" y1="17" x2="8" y2="17"></line>
+                    </svg>
+                    <span class="nav-label">Prompt Presets</span>
+                </button>
+                <button type="button" class="nav-item" data-target="sectionScraping">
+                    <svg class="nav-icon" width="16" height="16" viewBox="0 0 24 24" fill="none"
+                        stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                        aria-hidden="true">
+                        <line x1="4" y1="21" x2="4" y2="14"></line>
+                        <line x1="4" y1="10" x2="4" y2="3"></line>
+                        <line x1="12" y1="21" x2="12" y2="12"></line>
+                        <line x1="12" y1="8" x2="12" y2="3"></line>
+                        <line x1="20" y1="21" x2="20" y2="16"></line>
+                        <line x1="20" y1="12" x2="20" y2="3"></line>
+                        <line x1="1" y1="14" x2="7" y2="14"></line>
+                        <line x1="9" y1="8" x2="15" y2="8"></line>
+                        <line x1="17" y1="16" x2="23" y2="16"></line>
+                    </svg>
+                    <span class="nav-label">Scraping & Filters</span>
+                </button>
+                <button type="button" class="nav-item" data-target="sectionMappings">
+                    <svg class="nav-icon" width="16" height="16" viewBox="0 0 24 24" fill="none"
+                        stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                        aria-hidden="true">
+                        <polyline points="16 3 21 3 21 8"></polyline>
+                        <line x1="4" y1="20" x2="21" y2="3"></line>
+                        <polyline points="21 16 21 21 16 21"></polyline>
+                        <line x1="15" y1="15" x2="21" y2="21"></line>
+                        <line x1="4" y1="4" x2="9" y2="9"></line>
+                    </svg>
+                    <span class="nav-label">Subreddit Mappings</span>
+                </button>
+                <button type="button" class="nav-item" data-target="sectionCustom">
+                    <svg class="nav-icon" width="16" height="16" viewBox="0 0 24 24" fill="none"
+                        stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                        aria-hidden="true">
+                        <rect x="2" y="2" width="20" height="8" rx="2" ry="2"></rect>
+                        <rect x="2" y="14" width="20" height="8" rx="2" ry="2"></rect>
+                        <line x1="6" y1="6" x2="6.01" y2="6"></line>
+                        <line x1="6" y1="18" x2="6.01" y2="18"></line>
+                    </svg>
+                    <span class="nav-label">Custom WebUIs</span>
+                </button>
             </nav>
 
             <div id="sectionAi" class="settings-pane active">
@@ -161,6 +216,33 @@
                                 <option value="executive">Executive summary</option>
                             </select>
                         </div>
+                    </div>
+                </div>
+
+                <!-- Direct API Card -->
+                <div class="card">
+                    <div class="card-header">
+                        <svg class="card-icon" width="20" height="20" viewBox="0 0 24 24" fill="none"
+                            stroke="currentColor" stroke-width="2">
+                            <path d="M15 7h3a5 5 0 0 1 0 10h-3"></path>
+                            <path d="M9 17H6A5 5 0 0 1 6 7h3"></path>
+                            <path d="M8 12h8"></path>
+                        </svg>
+                        <h2 class="card-title" data-i18n="options_card_direct_api_title">Direct API</h2>
+                    </div>
+                    <div class="card-content">
+                        <p class="form-hint" data-i18n="options_direct_api_intro">
+                            Add your own provider API key to get answers inside the prompt preview page,
+                            without opening an AI chat tab.
+                        </p>
+                        <p class="api-warning" data-i18n="options_direct_api_warning">
+                            Keys are stored locally on this device only — they are never synced to your
+                            Google account and never included in a settings export. Requests go directly
+                            from your browser to the provider, and you are billed by that provider.
+                        </p>
+
+                        <div class="api-provider-list" id="apiProviderList"></div>
+                        <div class="api-key-status" id="apiKeyStatus" role="status"></div>
                     </div>
                 </div>
             </div>
@@ -433,34 +515,34 @@
                         <h2 class="card-title">Selector Overrides</h2>
                     </div>
                     <div class="card-content">
-                        <p class="form-hint" style="margin-bottom: 12px;">Override the target input field CSS selectors for each AI platform if they break.</p>
+                        <p class="form-hint form-hint-lead">Override the target input field CSS selectors for each AI platform if they break.</p>
                         <div class="form-group">
                             <label class="form-label" for="selectorGemini">Gemini Selector</label>
-                            <input type="text" id="selectorGemini" class="search-input" placeholder="e.g. div.rich-textarea [contenteditable='true']" style="width: 100%; box-sizing: border-box;">
+                            <input type="text" id="selectorGemini" class="search-input" placeholder="e.g. div.rich-textarea [contenteditable='true']">
                         </div>
                         <div class="form-group">
                             <label class="form-label" for="selectorChatgpt">ChatGPT Selector</label>
-                            <input type="text" id="selectorChatgpt" class="search-input" placeholder="e.g. #prompt-textarea" style="width: 100%; box-sizing: border-box;">
+                            <input type="text" id="selectorChatgpt" class="search-input" placeholder="e.g. #prompt-textarea">
                         </div>
                         <div class="form-group">
                             <label class="form-label" for="selectorClaude">Claude Selector</label>
-                            <input type="text" id="selectorClaude" class="search-input" placeholder="e.g. div[contenteditable='true']" style="width: 100%; box-sizing: border-box;">
+                            <input type="text" id="selectorClaude" class="search-input" placeholder="e.g. div[contenteditable='true']">
                         </div>
                         <div class="form-group">
                             <label class="form-label" for="selectorAistudio">AI Studio Selector</label>
-                            <input type="text" id="selectorAistudio" class="search-input" placeholder="e.g. textarea" style="width: 100%; box-sizing: border-box;">
+                            <input type="text" id="selectorAistudio" class="search-input" placeholder="e.g. textarea">
                         </div>
                         <div class="form-group">
                             <label class="form-label" for="selectorDeepseek">DeepSeek Selector</label>
-                            <input type="text" id="selectorDeepseek" class="search-input" placeholder="e.g. textarea, div[contenteditable='true']" style="width: 100%; box-sizing: border-box;">
+                            <input type="text" id="selectorDeepseek" class="search-input" placeholder="e.g. textarea, div[contenteditable='true']">
                         </div>
                         <div class="form-group">
                             <label class="form-label" for="selectorGroq">Groq Selector</label>
-                            <input type="text" id="selectorGroq" class="search-input" placeholder="e.g. textarea, #chat-input, div[contenteditable='true']" style="width: 100%; box-sizing: border-box;">
+                            <input type="text" id="selectorGroq" class="search-input" placeholder="e.g. textarea, #chat-input, div[contenteditable='true']">
                         </div>
                         <div class="form-group">
                             <label class="form-label" for="selectorCustom">Custom Platform Selector</label>
-                            <input type="text" id="selectorCustom" class="search-input" placeholder="e.g. textarea, div[contenteditable='true']" style="width: 100%; box-sizing: border-box;">
+                            <input type="text" id="selectorCustom" class="search-input" placeholder="e.g. textarea, div[contenteditable='true']">
                         </div>
                     </div>
                 </div>
@@ -666,24 +748,24 @@
                         <h2 class="card-title" data-i18n="options_card_mappings_title">Subreddit-Specific Templates</h2>
                     </div>
                     <div class="card-content">
-                        <p class="form-hint" style="margin-bottom: 12px;" data-i18n="options_mappings_hint">Override the default prompt template for specific subreddits (supports wildcards like <code>investing*</code>).</p>
-                        <div class="form-group" style="display: flex; gap: 8px; margin-bottom: 12px; align-items: center;">
-                            <input type="text" id="subredditPatternInput" class="search-input" data-i18n="options_mappings_placeholder" placeholder="e.g. cscareerquestions or investing*" style="flex: 2; box-sizing: border-box;">
-                            <select id="subredditPresetSelect" class="select-input" style="flex: 1; min-width: 110px;">
+                        <p class="form-hint form-hint-lead" data-i18n="options_mappings_hint">Override the default prompt template for specific subreddits (supports wildcards like <code>investing*</code>).</p>
+                        <div class="form-group form-row">
+                            <input type="text" id="subredditPatternInput" class="search-input form-row-grow-2" data-i18n="options_mappings_placeholder" placeholder="e.g. cscareerquestions or investing*">
+                            <select id="subredditPresetSelect" class="select-input form-row-grow">
                                 <option value="summarize">Summarize</option>
                                 <option value="debate">Debate</option>
                                 <option value="sentiment">Sentiment</option>
                                 <option value="takeaways">Takeaways</option>
                                 <option value="eli5">ELI5</option>
                             </select>
-                            <button type="button" id="addSubredditRuleBtn" class="btn primary" data-i18n="options_mappings_btn_add" style="white-space: nowrap;">Add Rule</button>
+                            <button type="button" id="addSubredditRuleBtn" class="btn primary btn-nowrap" data-i18n="options_mappings_btn_add">Add Rule</button>
                         </div>
-                        <ul id="subredditRulesList" class="custom-origins-list" style="list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 8px;"></ul>
+                        <ul id="subredditRulesList" class="custom-origins-list"></ul>
                     </div>
                 </div>
 
                 <!-- Subreddit Mapping Tester Card -->
-                <div class="card" style="margin-top: 16px;">
+                <div class="card">
                     <div class="card-header">
                         <svg class="card-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                             <polygon points="5 3 19 12 5 21 5 3" />
@@ -691,11 +773,11 @@
                         <h2 class="card-title" data-i18n="options_card_route_tester_title">Subreddit Mapping Tester</h2>
                     </div>
                     <div class="card-content">
-                        <p class="form-hint" style="margin-bottom: 12px;" data-i18n="options_route_tester_hint">Test your wildcard patterns against subreddit names to see which template resolves.</p>
-                        <div class="form-group" style="display: flex; gap: 8px; margin-bottom: 12px; align-items: center;">
-                            <input type="text" id="routeTesterInput" class="search-input" data-i18n="options_placeholder_route_tester" placeholder="e.g. investing or AskReddit" style="flex: 1; box-sizing: border-box;" data-tooltip="tooltip_route_tester_input">
+                        <p class="form-hint form-hint-lead" data-i18n="options_route_tester_hint">Test your wildcard patterns against subreddit names to see which template resolves.</p>
+                        <div class="form-group form-row">
+                            <input type="text" id="routeTesterInput" class="search-input form-row-grow" data-i18n="options_placeholder_route_tester" placeholder="e.g. investing or AskReddit" data-tooltip="tooltip_route_tester_input">
                         </div>
-                        <div id="routeTesterResult" class="tester-result" style="padding: 12px; border-radius: 8px; background: rgba(255, 255, 255, 0.02); border: 1px solid var(--border-color); font-size: 13px; display: none; transition: var(--transition);">
+                        <div id="routeTesterResult" class="tester-result" style="display: none;">
                             <!-- Result will be populated via JS -->
                         </div>
                     </div>
@@ -715,12 +797,12 @@
                         <h2 class="card-title">Custom AI Platforms / Local WebUIs</h2>
                     </div>
                     <div class="card-content">
-                        <p class="form-hint" style="margin-bottom: 12px;">Add custom WebUI origins (e.g. <code>http://localhost:3000</code> or <code>http://127.0.0.1:8080</code>) to dynamically request host permission and register content scripts.</p>
-                        <div class="form-group" style="display: flex; gap: 8px; margin-bottom: 12px;">
-                            <input type="text" id="customOriginInput" class="search-input" placeholder="e.g. http://localhost:3000" style="flex: 1; box-sizing: border-box;">
-                            <button type="button" id="addCustomOriginBtn" class="btn-action" style="white-space: nowrap; border-color: var(--accent); color: var(--accent);">Add Platform & Request Permission</button>
+                        <p class="form-hint form-hint-lead">Add custom WebUI origins (e.g. <code>http://localhost:3000</code> or <code>http://127.0.0.1:8080</code>) to dynamically request host permission and register content scripts.</p>
+                        <div class="form-group form-row">
+                            <input type="text" id="customOriginInput" class="search-input form-row-grow" placeholder="e.g. http://localhost:3000">
+                            <button type="button" id="addCustomOriginBtn" class="btn-action btn-accent-outline btn-nowrap">Add Platform & Request Permission</button>
                         </div>
-                        <ul id="customOriginsList" class="custom-origins-list" style="list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 8px;"></ul>
+                        <ul id="customOriginsList" class="custom-origins-list"></ul>
                     </div>
                 </div>
             </div>
@@ -728,7 +810,7 @@
 
         <!-- Footer -->
         <footer class="footer">
-            <span class="footer-text" data-i18n="footer_version_text">Reddit to AI v1.2.1</span>
+            <span class="footer-text" data-i18n="footer_version_text">Reddit to AI v1.3.0</span>
             <span class="footer-text" data-i18n="options_footer_saved">Settings are saved automatically</span>
         </footer>
     </div>
@@ -746,6 +828,7 @@
 
     <script src="i18n.js"></script>
     <script src="tooltip.js"></script>
+    <script src="apiProviders.js"></script>
     <script src="options.js"></script>
 </body>
 

--- a/src/options.js
+++ b/src/options.js
@@ -1106,30 +1106,45 @@ async function initializeOptions() {
         reader.readAsText(file);
     }
 
+    // Single source of truth for which settings travel through export/import, and
+    // what shape each one is allowed to have. Import rejects anything that is not
+    // listed here, so a hand-edited or hostile settings file cannot inject keys the
+    // rest of the extension never validates.
+    const PORTABLE_SETTING_TYPES = {
+        scrapeDepth: 'number',
+        showNotifications: 'boolean',
+        showPromptPreview: 'boolean',
+        customPromptTemplate: 'string',
+        selectedPreset: 'string',
+        dataStorageOption: 'string',
+        selectedLlmProvider: 'string',
+        filterMinScore: 'number',
+        filterTopN: 'number',
+        filterAuthorType: 'string',
+        filterAuthorTypes: 'array',
+        filterHideBots: 'boolean',
+        includeHidden: 'boolean',
+        contextPreset: 'string',
+        trimStrategy: 'string',
+        redditSortMode: 'string',
+        mediaMode: 'string',
+        outputFormat: 'string',
+        selectedLanguage: 'string',
+        savedPromptPresets: 'array',
+        customSelectors: 'object'
+    };
+
+    const IMPORT_STATUS_KEY = 'pendingImportStatus';
+
+    function matchesExpectedType(value, expectedType) {
+        if (expectedType === 'array') return Array.isArray(value);
+        if (expectedType === 'object') return typeof value === 'object' && value !== null && !Array.isArray(value);
+        if (expectedType === 'number') return typeof value === 'number' && Number.isFinite(value);
+        return typeof value === expectedType;
+    }
+
     function exportSettings() {
-        const keys = [
-            'scrapeDepth',
-            'showNotifications',
-            'showPromptPreview',
-            'customPromptTemplate',
-            'selectedPreset',
-            'dataStorageOption',
-            'selectedLlmProvider',
-            'filterMinScore',
-            'filterTopN',
-            'filterAuthorType',
-            'filterAuthorTypes',
-            'filterHideBots',
-            'includeHidden',
-            'contextPreset',
-            'trimStrategy',
-            'redditSortMode',
-            'mediaMode',
-            'outputFormat',
-            'selectedLanguage',
-            'savedPromptPresets',
-            'customSelectors'
-        ];
+        const keys = Object.keys(PORTABLE_SETTING_TYPES);
         chrome.storage.sync.get(keys, (settings) => {
             downloadJson(`reddit-to-ai-settings-${Date.now()}.json`, {
                 exportedAt: new Date().toISOString(),
@@ -1144,9 +1159,53 @@ async function initializeOptions() {
             alert('Imported file does not contain settings.');
             return;
         }
-        chrome.storage.sync.set(settings, () => {
+        const accepted = {};
+        let importedCount = 0;
+        let skippedCount = 0;
+        for (const [key, value] of Object.entries(settings)) {
+            const expectedType = PORTABLE_SETTING_TYPES[key];
+            // Unknown keys and wrong-typed values are dropped silently: an import
+            // file is untrusted input, not a way to write arbitrary storage keys.
+            if (!expectedType || !matchesExpectedType(value, expectedType)) {
+                skippedCount++;
+                continue;
+            }
+            accepted[key] = value;
+            importedCount++;
+        }
+
+        if (importedCount === 0) {
+            alert('Imported file does not contain any recognized settings.');
+            return;
+        }
+
+        chrome.storage.sync.set(accepted, () => {
+            if (chrome.runtime.lastError) {
+                alert(`Could not import settings: ${chrome.runtime.lastError.message}`);
+                return;
+            }
+            // Re-running the initializer here would re-attach every listener on top
+            // of the existing ones (double-save / double-delete). Reloading the page is
+            // the only way to rebuild the whole options UI from the new values with
+            // exactly one set of listeners bound.
+            const status = `Imported ${importedCount} setting${importedCount === 1 ? '' : 's'}` +
+                (skippedCount > 0 ? `, skipped ${skippedCount} unrecognized.` : '.');
+            chrome.storage.local.set({ [IMPORT_STATUS_KEY]: status }, () => {
+                void chrome.runtime.lastError;
+                location.reload();
+            });
+        });
+    }
+
+    // Surfaces the message stored just before the post-import reload, then clears it
+    // so a later manual reload does not repeat a stale status.
+    function showPendingImportStatus() {
+        chrome.storage.local.get([IMPORT_STATUS_KEY], (result) => {
+            const status = result?.[IMPORT_STATUS_KEY];
+            if (!status) return;
+            chrome.storage.local.remove([IMPORT_STATUS_KEY], () => void chrome.runtime.lastError);
+            setHistoryStatus(status, 'success');
             showSaveToast();
-            initializeOptions();
         });
     }
 
@@ -1533,6 +1592,8 @@ async function initializeOptions() {
         });
     }
 
+    showPendingImportStatus();
+
     if (clearSavedPresetsBtn) {
         clearSavedPresetsBtn.addEventListener('click', () => {
             if (confirm('Clear all saved prompt presets? This cannot be undone.')) {
@@ -1560,6 +1621,184 @@ async function initializeOptions() {
             }
         });
     }
+
+    // =====================
+    // Direct API keys
+    // =====================
+    //
+    // Keys are read from and written to chrome.storage.local exclusively. They are
+    // deliberately absent from PORTABLE_SETTING_TYPES, so exportSettings (which only
+    // walks that allowlist against chrome.storage.sync) can never emit them, and
+    // importSettings drops the key if a crafted import file contains one.
+
+    const apiProviderList = document.getElementById('apiProviderList');
+    const apiKeyStatus = document.getElementById('apiKeyStatus');
+    const DIRECT_API_CONFIG_KEY = 'directApiConfig';
+
+    function setApiKeyStatus(message, type = '') {
+        if (!apiKeyStatus) return;
+        apiKeyStatus.textContent = message;
+        apiKeyStatus.classList.toggle('error', type === 'error');
+        apiKeyStatus.classList.toggle('success', type === 'success');
+    }
+
+    function saveDirectApiConfig(provider, patch) {
+        chrome.storage.local.get([DIRECT_API_CONFIG_KEY], (result) => {
+            const config = (result && typeof result[DIRECT_API_CONFIG_KEY] === 'object' && result[DIRECT_API_CONFIG_KEY])
+                ? result[DIRECT_API_CONFIG_KEY]
+                : {};
+            const next = { ...config, [provider]: { ...(config[provider] || {}), ...patch } };
+            chrome.storage.local.set({ [DIRECT_API_CONFIG_KEY]: next }, () => {
+                if (chrome.runtime.lastError) {
+                    setApiKeyStatus(`Could not save: ${chrome.runtime.lastError.message}`, 'error');
+                    return;
+                }
+                showSaveToast();
+            });
+        });
+    }
+
+    function buildApiProviderRow(definition, stored) {
+        const row = document.createElement('div');
+        row.className = 'api-provider-row';
+
+        const heading = document.createElement('h3');
+        heading.className = 'api-provider-name';
+        heading.textContent = definition.label;
+        row.appendChild(heading);
+
+        // --- API key field (password type, with a show/hide toggle) ---
+        const keyGroup = document.createElement('div');
+        keyGroup.className = 'form-group';
+        const keyLabel = document.createElement('label');
+        keyLabel.className = 'form-label';
+        keyLabel.setAttribute('for', `apiKey_${definition.id}`);
+        keyLabel.textContent = t('options_direct_api_key_label') || 'API key';
+        keyGroup.appendChild(keyLabel);
+
+        const keyRow = document.createElement('div');
+        keyRow.className = 'api-key-row';
+        const keyInput = document.createElement('input');
+        keyInput.type = 'password';
+        keyInput.id = `apiKey_${definition.id}`;
+        keyInput.className = 'search-input';
+        keyInput.autocomplete = 'off';
+        keyInput.spellcheck = false;
+        keyInput.placeholder = t('options_direct_api_key_placeholder') || 'Paste your API key';
+        keyInput.value = stored.apiKey || '';
+        keyRow.appendChild(keyInput);
+
+        const revealBtn = document.createElement('button');
+        revealBtn.type = 'button';
+        revealBtn.className = 'btn-action';
+        revealBtn.textContent = t('options_direct_api_show') || 'Show';
+        revealBtn.addEventListener('click', () => {
+            const hidden = keyInput.type === 'password';
+            keyInput.type = hidden ? 'text' : 'password';
+            revealBtn.textContent = hidden
+                ? (t('options_direct_api_hide') || 'Hide')
+                : (t('options_direct_api_show') || 'Show');
+        });
+        keyRow.appendChild(revealBtn);
+        keyGroup.appendChild(keyRow);
+        row.appendChild(keyGroup);
+
+        // --- Model field: free text, prefilled with the current default ---
+        const modelGroup = document.createElement('div');
+        modelGroup.className = 'form-group';
+        const modelLabel = document.createElement('label');
+        modelLabel.className = 'form-label';
+        modelLabel.setAttribute('for', `apiModel_${definition.id}`);
+        modelLabel.textContent = t('options_direct_api_model_label') || 'Model';
+        modelGroup.appendChild(modelLabel);
+
+        const modelInput = document.createElement('input');
+        modelInput.type = 'text';
+        modelInput.id = `apiModel_${definition.id}`;
+        modelInput.className = 'search-input';
+        modelInput.spellcheck = false;
+        modelInput.placeholder = definition.defaultModel;
+        modelInput.value = stored.model || definition.defaultModel;
+        modelGroup.appendChild(modelInput);
+
+        const modelHint = document.createElement('span');
+        modelHint.className = 'form-hint';
+        // Free text rather than a <select> so a newly released model id works without
+        // waiting for an extension update.
+        modelHint.textContent = `${t('options_direct_api_model_hint') || 'Any model id this provider accepts.'} ${definition.suggestedModels.join(', ')}`;
+        modelGroup.appendChild(modelHint);
+        row.appendChild(modelGroup);
+
+        // --- Test button ---
+        const actions = document.createElement('div');
+        actions.className = 'api-provider-actions';
+        const testBtn = document.createElement('button');
+        testBtn.type = 'button';
+        testBtn.className = 'btn-action';
+        testBtn.textContent = t('options_direct_api_test') || 'Test key';
+        testBtn.addEventListener('click', () => {
+            const apiKey = keyInput.value.trim();
+            if (!apiKey) {
+                setApiKeyStatus(t('options_direct_api_test_no_key') || 'Enter an API key first.', 'error');
+                return;
+            }
+            testBtn.disabled = true;
+            setApiKeyStatus(`${t('options_direct_api_testing') || 'Testing'} ${definition.label}…`);
+            chrome.runtime.sendMessage({
+                action: 'testDirectApiKey',
+                apiProvider: definition.id,
+                apiKey,
+                model: modelInput.value.trim()
+            }, (response) => {
+                testBtn.disabled = false;
+                if (chrome.runtime.lastError || response?.error || !response?.success) {
+                    const message = response?.error || chrome.runtime.lastError?.message || 'Unknown error';
+                    setApiKeyStatus(`${definition.label}: ${message}`, 'error');
+                    return;
+                }
+                setApiKeyStatus(
+                    `${definition.label}: ${t('options_direct_api_test_ok') || 'Key works.'} (${response.model})`,
+                    'success'
+                );
+            });
+        });
+        actions.appendChild(testBtn);
+
+        const clearBtn = document.createElement('button');
+        clearBtn.type = 'button';
+        clearBtn.className = 'btn-action btn-danger-outline';
+        clearBtn.textContent = t('options_direct_api_clear') || 'Remove key';
+        clearBtn.addEventListener('click', () => {
+            keyInput.value = '';
+            saveDirectApiConfig(definition.id, { apiKey: '' });
+            setApiKeyStatus(`${definition.label}: ${t('options_direct_api_cleared') || 'Key removed.'}`, 'success');
+        });
+        actions.appendChild(clearBtn);
+        row.appendChild(actions);
+
+        // Persist on blur rather than on every keystroke, so a partially pasted key
+        // is not written repeatedly.
+        keyInput.addEventListener('change', () => saveDirectApiConfig(definition.id, { apiKey: keyInput.value.trim() }));
+        modelInput.addEventListener('change', () => saveDirectApiConfig(definition.id, { model: modelInput.value.trim() }));
+
+        return row;
+    }
+
+    function renderDirectApiSection() {
+        if (!apiProviderList || typeof R2AIApiProviders === 'undefined') return;
+        chrome.storage.local.get([DIRECT_API_CONFIG_KEY], (result) => {
+            const config = (result && typeof result[DIRECT_API_CONFIG_KEY] === 'object' && result[DIRECT_API_CONFIG_KEY])
+                ? result[DIRECT_API_CONFIG_KEY]
+                : {};
+            apiProviderList.innerHTML = '';
+            R2AIApiProviders.PROVIDER_IDS.forEach(id => {
+                const definition = R2AIApiProviders.PROVIDERS[id];
+                apiProviderList.appendChild(buildApiProviderRow(definition, config[id] || {}));
+            });
+        });
+    }
+
+    renderDirectApiSection();
 
     // Initial history load
     loadHistory();

--- a/src/popup.css
+++ b/src/popup.css
@@ -1,26 +1,55 @@
-/* Reddit to AI - Popup Styles */
+/* Reddit to AI — Popup Styles (Ember design system) */
 
 :root {
-  --bg-primary: #0d0d0d;
-  --bg-secondary: rgba(26, 26, 27, 0.6);
-  --bg-card: rgba(39, 39, 42, 0.4);
-  --bg-glass: rgba(255, 255, 255, 0.03);
-  --bg-glass-hover: rgba(255, 255, 255, 0.06);
-  --border-color: rgba(255, 255, 255, 0.08);
-  --text-primary: #ffffff;
-  --text-secondary: #a0a0a0;
-  --text-muted: #6b6b6b;
-  --accent: #FF4500;
-  --accent-hover: #ff5722;
-  --accent-glow: rgba(255, 69, 0, 0.3);
-  --success: #10b981;
-  --error: #ef4444;
-  --warning: #f59e0b;
-  --info: #3b82f6;
-  --radius-sm: 8px;
-  --radius-md: 12px;
-  --blur: 12px;
-  --transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  /* Surfaces */
+  --bg: #09090b;
+  --surface: #121214;
+  --surface-2: #1a1a1e;
+  --surface-3: #232329;
+  --overlay: rgba(9, 9, 11, 0.72);
+
+  /* Borders */
+  --border: rgba(255, 255, 255, 0.07);
+  --border-strong: rgba(255, 255, 255, 0.14);
+
+  /* Text */
+  --text: #f4f4f5;
+  --text-2: #a1a1aa;
+  --text-3: #63636b;
+
+  /* Brand */
+  --accent: #ff4500;
+  --accent-bright: #ff6a2b;
+  --accent-grad: linear-gradient(135deg, #ff4500 0%, #ff6a2b 100%);
+  --accent-soft: rgba(255, 69, 0, 0.12);
+  --accent-border: rgba(255, 69, 0, 0.35);
+  --accent-glow: rgba(255, 69, 0, 0.25);
+
+  /* Status */
+  --success: #34d399;
+  --warning: #fbbf24;
+  --danger: #f87171;
+  --info: #60a5fa;
+
+  /* Shape */
+  --r-sm: 8px;
+  --r-md: 12px;
+  --r-lg: 16px;
+  --r-full: 999px;
+
+  /* Elevation */
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+  --shadow-md: 0 8px 24px rgba(0, 0, 0, 0.45);
+  --shadow-lg: 0 16px 48px rgba(0, 0, 0, 0.55);
+
+  /* Motion */
+  --ease: cubic-bezier(0.4, 0, 0.2, 1);
+  --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+  --t-fast: 0.15s;
+  --t-med: 0.25s;
+
+  /* Focus */
+  --ring: 0 0 0 3px rgba(255, 69, 0, 0.28);
 }
 
 * {
@@ -30,35 +59,53 @@
 }
 
 body {
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-  width: 320px;
-  background: var(--bg-primary);
-  background-image: radial-gradient(circle at 50% 0%, rgba(255, 69, 0, 0.05) 0%, transparent 50%);
-  color: var(--text-primary);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  width: 340px;
+  background: var(--bg);
+  color: var(--text);
   font-size: 13px;
   line-height: 1.5;
   min-height: auto;
-  /* Reserve scrollbar space at all times so layout never shifts */
   scrollbar-gutter: stable;
-  overflow-y: auto;
+  overflow-y: scroll;
+  -webkit-font-smoothing: antialiased;
 }
 
-/* Thin, unobtrusive scrollbar */
-body::-webkit-scrollbar {
-  width: 4px;
+/* Scrollbars */
+body::-webkit-scrollbar,
+.summary-result-content-wrap::-webkit-scrollbar {
+  width: 6px;
 }
 
-body::-webkit-scrollbar-track {
+body::-webkit-scrollbar-track,
+.summary-result-content-wrap::-webkit-scrollbar-track {
   background: transparent;
 }
 
-body::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.1);
-  border-radius: 2px;
+body::-webkit-scrollbar-thumb,
+.summary-result-content-wrap::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.12);
+  border-radius: var(--r-full);
 }
 
-body::-webkit-scrollbar-thumb:hover {
-  background: rgba(255, 255, 255, 0.2);
+body::-webkit-scrollbar-thumb:hover,
+.summary-result-content-wrap::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.22);
+}
+
+/* Global focus ring */
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+[role="tab"]:focus-visible {
+  outline: none;
+  box-shadow: var(--ring);
+}
+
+.depth-card-mini input[type="radio"]:focus-visible + span,
+.toggle-switch input:focus-visible + .toggle-slider {
+  box-shadow: var(--ring);
 }
 
 .popup-container {
@@ -79,29 +126,32 @@ body::-webkit-scrollbar-thumb:hover {
   z-index: 1000;
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 8px;
   pointer-events: none;
 }
 
 .toast {
   display: flex;
   align-items: flex-start;
-  gap: 10px;
+  gap: 8px;
   padding: 10px 12px;
-  border-radius: var(--radius-md);
+  border-radius: var(--r-md);
+  background: rgba(26, 26, 30, 0.88);
   backdrop-filter: blur(16px);
   -webkit-backdrop-filter: blur(16px);
-  border: 1px solid;
+  border: 1px solid var(--border-strong);
+  border-left-width: 3px;
+  box-shadow: var(--shadow-md), inset 0 1px 0 rgba(255, 255, 255, 0.04);
   font-size: 12px;
   line-height: 1.4;
   pointer-events: all;
-  animation: toastSlideIn 0.25s cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+  animation: toastSlideIn var(--t-med) var(--ease-out) forwards;
   position: relative;
   overflow: hidden;
 }
 
 .toast.exiting {
-  animation: toastSlideOut 0.28s cubic-bezier(0.4, 0, 1, 1) forwards;
+  animation: toastSlideOut 0.28s var(--ease) forwards;
 }
 
 @keyframes toastSlideIn {
@@ -134,23 +184,19 @@ body::-webkit-scrollbar-thumb:hover {
 }
 
 .toast.info {
-  background: rgba(59, 130, 246, 0.12);
-  border-color: rgba(59, 130, 246, 0.28);
+  border-left-color: var(--info);
 }
 
 .toast.success {
-  background: rgba(16, 185, 129, 0.12);
-  border-color: rgba(16, 185, 129, 0.28);
+  border-left-color: var(--success);
 }
 
 .toast.error {
-  background: rgba(239, 68, 68, 0.12);
-  border-color: rgba(239, 68, 68, 0.28);
+  border-left-color: var(--danger);
 }
 
 .toast.progress {
-  background: rgba(245, 158, 11, 0.10);
-  border-color: rgba(245, 158, 11, 0.28);
+  border-left-color: var(--accent);
 }
 
 .toast-icon {
@@ -163,8 +209,24 @@ body::-webkit-scrollbar-thumb:hover {
   margin-top: 1px;
 }
 
+.toast.info .toast-icon {
+  color: var(--info);
+}
+
+.toast.success .toast-icon {
+  color: var(--success);
+}
+
+.toast.error .toast-icon {
+  color: var(--danger);
+}
+
+.toast.progress .toast-icon {
+  color: var(--accent);
+}
+
 .toast.progress .toast-icon svg {
-  animation: toastSpin 1.4s linear infinite;
+  animation: toastSpin 0.8s linear infinite;
 }
 
 @keyframes toastSpin {
@@ -183,7 +245,7 @@ body::-webkit-scrollbar-thumb:hover {
 }
 
 .toast-message {
-  color: var(--text-primary);
+  color: var(--text);
   font-size: 12px;
   line-height: 1.4;
 }
@@ -192,7 +254,7 @@ body::-webkit-scrollbar-thumb:hover {
   flex-shrink: 0;
   background: none;
   border: none;
-  color: var(--text-muted);
+  color: var(--text-3);
   cursor: pointer;
   padding: 0;
   display: flex;
@@ -200,14 +262,14 @@ body::-webkit-scrollbar-thumb:hover {
   justify-content: center;
   width: 16px;
   height: 16px;
-  border-radius: 50%;
-  transition: var(--transition);
+  border-radius: var(--r-full);
+  transition: color var(--t-fast) var(--ease), background var(--t-fast) var(--ease);
   margin-top: 1px;
 }
 
 .toast-dismiss:hover {
-  color: var(--text-secondary);
-  background: rgba(255, 255, 255, 0.1);
+  color: var(--text-2);
+  background: rgba(255, 255, 255, 0.08);
 }
 
 .toast-progress-bar {
@@ -215,10 +277,9 @@ body::-webkit-scrollbar-thumb:hover {
   bottom: 0;
   left: 0;
   height: 2px;
-  background: var(--warning);
-  opacity: 0.5;
-  border-radius: 0 0 var(--radius-md) var(--radius-md);
-  transition: width 0.4s ease;
+  background: var(--accent-grad);
+  border-radius: var(--r-full);
+  transition: width 0.35s var(--ease);
 }
 
 /* ── Header ───────────────────────────────────────────────── */
@@ -232,33 +293,32 @@ body::-webkit-scrollbar-thumb:hover {
 .logo {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 8px;
 }
 
 .logo-icon {
-  width: 28px;
-  height: 28px;
-  filter: drop-shadow(0 2px 6px var(--accent-glow));
+  width: 24px;
+  height: 24px;
 }
 
 .logo-text {
-  font-size: 18px;
+  font-size: 15px;
   font-weight: 700;
-  letter-spacing: -0.5px;
+  letter-spacing: -0.02em;
 }
 
 .logo-reddit {
-  color: var(--accent);
+  color: var(--accent-bright);
 }
 
 .logo-to {
-  color: var(--text-muted);
+  color: var(--text-3);
   margin: 0 2px;
   font-weight: 400;
 }
 
 .logo-ai {
-  color: var(--text-primary);
+  color: var(--text);
 }
 
 .header-actions {
@@ -268,65 +328,70 @@ body::-webkit-scrollbar-thumb:hover {
 }
 
 .settings-btn {
-  width: 36px;
-  height: 36px;
+  width: 32px;
+  height: 32px;
   display: flex;
   align-items: center;
   justify-content: center;
-  background: var(--bg-glass);
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-sm);
-  color: var(--text-secondary);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--r-sm);
+  color: var(--text-2);
   cursor: pointer;
-  transition: var(--transition);
+  transition: color var(--t-fast) var(--ease), background var(--t-fast) var(--ease), border-color var(--t-fast) var(--ease);
 }
 
 .settings-btn:hover {
-  background: var(--bg-card);
-  color: var(--text-primary);
-  border-color: rgba(255, 255, 255, 0.2);
+  background: var(--surface-2);
+  border-color: var(--border);
+  color: var(--text);
 }
 
-/* ── Tab Navigation ───────────────────────────────────────── */
+.settings-btn svg {
+  width: 16px;
+  height: 16px;
+}
+
+/* ── Tab Navigation (segmented control) ───────────────────── */
 
 .tabs-list {
   display: flex;
-  background: rgba(255, 255, 255, 0.03);
-  border: 1px solid var(--border-color);
-  border-radius: 20px;
-  padding: 2px;
-  margin-bottom: 2px;
+  gap: 2px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  padding: 3px;
 }
 
 .tab-trigger {
   flex: 1;
-  border: none;
+  border: 1px solid transparent;
   background: none;
-  color: var(--text-secondary);
+  color: var(--text-2);
   font-size: 12px;
   font-weight: 600;
-  padding: 6px 12px;
-  border-radius: 18px;
+  font-family: inherit;
+  padding: 5px 12px;
+  border-radius: 6px;
   cursor: pointer;
-  transition: var(--transition);
+  transition: color var(--t-fast) var(--ease), background var(--t-fast) var(--ease);
 }
 
 .tab-trigger:hover {
-  color: var(--text-primary);
+  color: var(--text);
 }
 
 .tab-trigger.active {
-  background: var(--bg-card);
-  color: var(--text-primary);
-  box-shadow: 0 0 8px rgba(255, 69, 0, 0.2);
-  border: 1px solid rgba(255, 69, 0, 0.3);
+  background: var(--surface-3);
+  border-color: var(--border);
+  color: var(--text);
+  box-shadow: var(--shadow-sm), inset 0 1px 0 rgba(255, 255, 255, 0.04);
 }
 
-/* Flex container for children with standard spacing to prevent jank/overlap */
 .tab-content {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 10px;
   min-height: 0;
 }
 
@@ -339,15 +404,11 @@ body::-webkit-scrollbar-thumb:hover {
 .preset-section {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 8px;
 }
 
 .section-label {
-  font-size: 11px;
-  font-weight: 600;
-  color: var(--text-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
+  display: none;
 }
 
 .preset-cards {
@@ -361,62 +422,53 @@ body::-webkit-scrollbar-thumb:hover {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 4px;
-  padding: 8px 4px;
-  background: var(--bg-card);
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-sm);
+  gap: 3px;
+  padding: 8px 4px 6px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
   cursor: pointer;
-  transition: var(--transition);
+  transition: background var(--t-fast) var(--ease), border-color var(--t-fast) var(--ease);
   position: relative;
-  overflow: hidden;
 }
 
 .preset-card:hover {
-  border-color: rgba(255, 255, 255, 0.4);
-  transform: translateY(-2px);
-  background: var(--bg-glass-hover);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+  border-color: var(--border-strong);
+  background: var(--surface-2);
 }
 
 .preset-card.selected {
-  border-color: var(--accent);
-  background: linear-gradient(135deg, rgba(255, 69, 0, 0.2) 0%, rgba(39, 39, 42, 0.6) 100%);
-  box-shadow: 0 0 16px var(--accent-glow);
-}
-
-.preset-card.selected::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 2px;
-  background: linear-gradient(90deg, transparent, var(--accent), transparent);
+  background: var(--accent-soft);
+  border-color: var(--accent-border);
 }
 
 .preset-icon {
   width: 20px;
   height: 20px;
-  transition: var(--transition);
-  filter: grayscale(0.2);
+  filter: grayscale(0.35);
+  opacity: 0.85;
+  transition: filter var(--t-fast) var(--ease), opacity var(--t-fast) var(--ease);
 }
 
 .preset-card:hover .preset-icon,
 .preset-card.selected .preset-icon {
-  filter: grayscale(0) drop-shadow(0 0 4px var(--accent-glow));
-  transform: scale(1.1);
+  filter: grayscale(0);
+  opacity: 1;
 }
 
 .preset-name {
   font-size: 10px;
   font-weight: 500;
-  color: var(--text-secondary);
-  transition: var(--transition);
+  color: var(--text-2);
+  transition: color var(--t-fast) var(--ease);
+}
+
+.preset-card:hover .preset-name {
+  color: var(--text);
 }
 
 .preset-card.selected .preset-name {
-  color: var(--text-primary);
+  color: var(--accent-bright);
   font-weight: 600;
 }
 
@@ -437,37 +489,90 @@ body::-webkit-scrollbar-thumb:hover {
   margin-top: 8px;
 }
 
+.quick-prompt-input {
+  width: 100%;
+  min-height: 36px;
+  max-height: 72px;
+  resize: none;
+  overflow: hidden;
+  padding: 8px 12px;
+  background-color: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  color: var(--text);
+  font-size: 12px;
+  font-family: ui-monospace, 'SF Mono', SFMono-Regular, Menlo, Consolas, monospace;
+  line-height: 1.5;
+  transition: border-color var(--t-fast) var(--ease), background-color var(--t-fast) var(--ease), box-shadow var(--t-fast) var(--ease);
+  display: block;
+}
+
+.quick-prompt-input::placeholder {
+  color: var(--text-3);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+}
+
+.quick-prompt-input:hover {
+  border-color: var(--border-strong);
+}
+
+.quick-prompt-input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: var(--ring);
+  overflow: auto;
+}
+
+.quick-prompt-input.has-content {
+  border-color: var(--accent-border);
+  background-color: var(--surface-2);
+}
+
 .compact-select {
-  height: 34px;
+  height: 32px;
   min-width: 0;
   flex: 1;
-  padding: 0 9px;
-  border-radius: var(--radius-sm);
-  border: 1px solid var(--border-color);
-  background: rgba(10, 10, 10, 0.78);
-  color: var(--text-primary);
+  padding: 0 8px;
+  border-radius: var(--r-sm);
+  border: 1px solid var(--border);
+  background: var(--surface-2);
+  color: var(--text);
   font: inherit;
   font-size: 12px;
+  cursor: pointer;
+  transition: border-color var(--t-fast) var(--ease), background var(--t-fast) var(--ease);
+}
+
+.compact-select:hover {
+  border-color: var(--border-strong);
+  background: var(--surface-3);
+}
+
+.compact-select:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: var(--ring);
 }
 
 .text-action-btn {
-  height: 34px;
-  padding: 0 10px;
-  border-radius: var(--radius-sm);
-  border: 1px solid var(--border-color);
-  background: var(--bg-glass);
-  color: var(--text-secondary);
+  height: 32px;
+  padding: 0 12px;
+  border-radius: var(--r-sm);
+  border: 1px solid var(--border);
+  background: var(--surface-2);
+  color: var(--text-2);
   font: inherit;
   font-size: 12px;
-  font-weight: 700;
+  font-weight: 600;
   cursor: pointer;
-  transition: var(--transition);
+  white-space: nowrap;
+  transition: color var(--t-fast) var(--ease), border-color var(--t-fast) var(--ease), background var(--t-fast) var(--ease);
 }
 
 .text-action-btn:hover:not(:disabled) {
-  color: var(--text-primary);
-  border-color: rgba(255, 255, 255, 0.18);
-  background: var(--bg-glass-hover);
+  color: var(--text);
+  border-color: var(--border-strong);
+  background: var(--surface-3);
 }
 
 .text-action-btn:disabled {
@@ -475,14 +580,79 @@ body::-webkit-scrollbar-thumb:hover {
   cursor: not-allowed;
 }
 
-.send-mode-section {
+.text-action-btn.primary {
+  border-color: var(--accent-border);
+  color: var(--text);
+  background: var(--surface-3);
+}
+
+/* ── Inline preset-name prompt ────────────────────────────── */
+
+.preset-name-row {
   display: flex;
   flex-direction: column;
   gap: 6px;
-  padding: 8px 10px;
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-sm);
-  background: var(--bg-card);
+  margin-top: 8px;
+  padding: 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--surface-2);
+}
+
+.preset-name-row[hidden] {
+  display: none;
+}
+
+.preset-name-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-2);
+}
+
+.preset-name-input {
+  width: 100%;
+  height: 32px;
+  padding: 0 8px;
+  border-radius: var(--r-sm);
+  border: 1px solid var(--border);
+  background: var(--surface-1, var(--surface-2));
+  color: var(--text);
+  font: inherit;
+  font-size: 12px;
+  transition: border-color var(--t-fast) var(--ease), box-shadow var(--t-fast) var(--ease);
+}
+
+.preset-name-input:hover {
+  border-color: var(--border-strong);
+}
+
+.preset-name-input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: var(--ring);
+}
+
+.preset-name-actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.preset-name-actions .text-action-btn {
+  flex: 1;
+}
+
+/* ── Send Mode Card ───────────────────────────────────────── */
+
+.send-mode-section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--surface);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
 }
 
 .mode-field {
@@ -490,19 +660,20 @@ body::-webkit-scrollbar-thumb:hover {
   min-width: 0;
   display: flex;
   flex-direction: column;
-  gap: 5px;
+  gap: 4px;
 }
 
 .mode-field span,
 .scrape-estimate {
-  color: var(--text-muted);
+  color: var(--text-3);
   font-size: 11px;
 }
 
 .mode-field span {
-  font-weight: 700;
+  font-size: 10px;
+  font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.06em;
 }
 
 .privacy-toggle {
@@ -518,82 +689,161 @@ body::-webkit-scrollbar-thumb:hover {
   display: flex;
   flex-direction: column;
   gap: 4px;
-  margin-top: 6px;
+  margin-top: 4px;
 }
+
 .budget-bar-track {
   width: 100%;
-  height: 4px;
-  background: rgba(255, 255, 255, 0.08);
-  border-radius: 2px;
+  height: 6px;
+  background: var(--surface-3);
+  border-radius: var(--r-full);
   overflow: hidden;
 }
+
 .budget-bar-fill {
   height: 100%;
   width: 0%;
-  border-radius: 2px;
-  transition: width 0.3s ease, background-color 0.3s ease;
+  border-radius: var(--r-full);
+  transition: width 0.35s var(--ease), background-color 0.35s var(--ease);
 }
+
 .budget-bar-fill.safe {
   background: var(--success);
 }
+
 .budget-bar-fill.moderate {
   background: var(--warning);
 }
+
 .budget-bar-fill.large {
-  background: var(--accent);
-}
-.budget-text {
-  font-size: 11px;
-  color: var(--text-muted);
+  background: var(--accent-grad);
 }
 
+.budget-text {
+  display: none;
+}
 
 .field-hint {
-  margin: 2px 0 0;
-  color: var(--text-muted);
+  margin: 4px 0 0;
+  color: var(--text-3);
   font-size: 11px;
   line-height: 1.35;
 }
 
-.quick-prompt-input {
-  width: 100%;
-  min-height: 34px;
-  max-height: 72px;
-  resize: none;
-  overflow: hidden;
-  padding: 7px 12px;
-  background-color: var(--bg-glass);
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-sm);
-  color: var(--text-primary);
-  font-size: 12px;
+/* ── Action Buttons ───────────────────────────────────────── */
+
+.btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 11px 16px;
+  border: none;
+  border-radius: var(--r-md);
+  font-size: 13px;
+  font-weight: 600;
   font-family: inherit;
-  line-height: 1.5;
-  transition: var(--transition);
-  display: block;
+  cursor: pointer;
+  transition: filter var(--t-fast) var(--ease), box-shadow var(--t-fast) var(--ease), transform var(--t-fast) var(--ease);
 }
 
-.quick-prompt-input::placeholder {
-  color: var(--text-muted);
-  font-style: italic;
+.btn:active {
+  transform: scale(0.98);
 }
 
-.quick-prompt-input:hover {
-  border-color: rgba(255, 255, 255, 0.15);
-  background-color: var(--bg-glass-hover);
+.btn-primary {
+  background: var(--accent-grad);
+  color: #fff;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.16);
 }
 
-.quick-prompt-input:focus {
-  outline: none;
-  border-color: var(--accent);
-  background-color: rgba(255, 69, 0, 0.04);
-  box-shadow: 0 0 0 2px rgba(255, 69, 0, 0.1);
-  overflow: auto;
+.btn-primary:hover {
+  filter: brightness(1.08);
+  box-shadow: 0 4px 20px var(--accent-glow), inset 0 1px 0 rgba(255, 255, 255, 0.16);
 }
 
-.quick-prompt-input.has-content {
-  border-color: rgba(255, 69, 0, 0.4);
-  background-color: rgba(255, 69, 0, 0.04);
+.btn-danger {
+  background: linear-gradient(135deg, #ef4444 0%, var(--danger) 100%);
+  color: #fff;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.14);
+}
+
+.btn-danger:hover {
+  filter: brightness(1.06);
+  box-shadow: 0 4px 20px rgba(248, 113, 113, 0.25), inset 0 1px 0 rgba(255, 255, 255, 0.14);
+}
+
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
+  filter: none;
+  box-shadow: none;
+}
+
+.btn-icon {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+}
+
+/* ── Export Chips ─────────────────────────────────────────── */
+
+.popup-export-container {
+  display: flex;
+  flex-direction: column;
+}
+
+.export-chips-row {
+  display: flex;
+  gap: 6px;
+  width: 100%;
+}
+
+.export-chip {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  height: 32px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  color: var(--text-2);
+  font-size: 11px;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+  transition: color var(--t-fast) var(--ease), border-color var(--t-fast) var(--ease), background var(--t-fast) var(--ease);
+}
+
+.export-chip:hover:not(.disabled) {
+  border-color: var(--border-strong);
+  background: var(--surface-3);
+  color: var(--text);
+}
+
+.export-chip.disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+.chip-icon {
+  font-size: 9px;
+  font-weight: 700;
+  font-family: ui-monospace, 'SF Mono', SFMono-Regular, Menlo, Consolas, monospace;
+  background: var(--surface-3);
+  border: 1px solid var(--border);
+  color: var(--text-3);
+  padding: 1px 4px;
+  border-radius: 4px;
+  transition: color var(--t-fast) var(--ease);
+}
+
+.export-chip:hover:not(.disabled) .chip-icon {
+  color: var(--accent-bright);
 }
 
 /* ── Filters Section ──────────────────────────────────────── */
@@ -601,11 +851,12 @@ body::-webkit-scrollbar-thumb:hover {
 .filters-section {
   display: flex;
   flex-direction: column;
-  gap: 10px;
-  padding: 10px 12px;
-  background: var(--bg-card);
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-md);
+  gap: 12px;
+  padding: 12px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
 }
 
 .filters-header {
@@ -615,11 +866,11 @@ body::-webkit-scrollbar-thumb:hover {
 }
 
 .filters-title {
-  font-size: 11px;
+  font-size: 10px;
   font-weight: 600;
-  color: var(--text-muted);
+  color: var(--text-3);
   text-transform: uppercase;
-  letter-spacing: 0.5px;
+  letter-spacing: 0.06em;
 }
 
 .expand-filters-btn {
@@ -627,22 +878,23 @@ body::-webkit-scrollbar-thumb:hover {
   align-items: center;
   justify-content: center;
   background: none;
-  border: none;
-  color: var(--text-muted);
+  border: 1px solid transparent;
+  color: var(--text-3);
   cursor: pointer;
-  padding: 3px;
-  border-radius: 4px;
-  transition: var(--transition);
+  width: 24px;
+  height: 24px;
+  border-radius: 6px;
+  transition: color var(--t-fast) var(--ease), background var(--t-fast) var(--ease);
   line-height: 0;
 }
 
 .expand-filters-btn:hover {
-  color: var(--text-secondary);
-  background: var(--bg-glass-hover);
+  color: var(--text-2);
+  background: var(--surface-2);
 }
 
 .expand-arrow {
-  transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+  transition: transform var(--t-med) var(--ease);
 }
 
 .expand-filters-btn[aria-expanded="true"] .expand-arrow {
@@ -658,127 +910,78 @@ body::-webkit-scrollbar-thumb:hover {
   flex-wrap: wrap;
 }
 
-/* ── Custom Select Dropdown ───────────────────────────────── */
-
-.custom-select-wrap {
-  position: relative;
+.pill-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  height: 28px;
+  padding: 0 12px;
+  background-color: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--r-full);
+  color: var(--text-2);
+  font-size: 11px;
+  font-family: inherit;
+  font-weight: 500;
+  cursor: pointer;
+  transition: color var(--t-fast) var(--ease), border-color var(--t-fast) var(--ease), background-color var(--t-fast) var(--ease);
+  white-space: nowrap;
   flex-shrink: 0;
+}
+
+.pill-toggle:hover {
+  border-color: var(--border-strong);
+  color: var(--text);
+  background-color: var(--surface-3);
+}
+
+.pill-toggle.active {
+  background-color: var(--accent-soft);
+  border-color: var(--accent-border);
+  color: var(--accent-bright);
+}
+
+/* ── Compact Filter Select ────────────────────────────────── */
+
+/* Native <select> wearing the pill styling of the old custom dropdown. */
+.filter-select-native {
+  flex-shrink: 0;
+  appearance: none;
+  -webkit-appearance: none;
+  padding-right: 26px;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6' fill='none'%3E%3Cpath d='M1 1l4 4 4-4' stroke='%23a1a1aa' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+}
+
+.filter-select-native:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: var(--ring);
 }
 
 .filter-select-compact {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  height: 26px;
-  padding: 0 10px;
-  background-color: var(--bg-glass);
-  border: 1px solid var(--border-color);
-  border-radius: 16px;
-  color: var(--text-secondary);
+  height: 28px;
+  padding: 0 12px;
+  background-color: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--r-full);
+  color: var(--text-2);
   font-size: 11px;
   font-family: inherit;
   font-weight: 500;
   cursor: pointer;
-  transition: var(--transition);
+  transition: color var(--t-fast) var(--ease), border-color var(--t-fast) var(--ease), background-color var(--t-fast) var(--ease);
   white-space: nowrap;
 }
 
 .filter-select-compact:hover {
-  border-color: rgba(255, 255, 255, 0.2);
-  background-color: var(--bg-glass-hover);
-  color: var(--text-primary);
-}
-
-.filter-select-compact[aria-expanded="true"] {
-  border-color: var(--accent);
-  background-color: rgba(255, 69, 0, 0.08);
-  color: var(--text-primary);
-}
-
-.custom-select-arrow {
-  flex-shrink: 0;
-  color: var(--text-muted);
-  transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1);
-}
-
-.filter-select-compact[aria-expanded="true"] .custom-select-arrow {
-  transform: rotate(180deg);
-  color: var(--accent);
-}
-
-.custom-select-dropdown {
-  position: absolute;
-  top: calc(100% + 4px);
-  left: 0;
-  z-index: 200;
-  background: #1c1c1e;
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-sm);
-  overflow: hidden;
-  min-width: 100%;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5), 0 2px 8px rgba(0, 0, 0, 0.3);
-}
-
-.custom-select-dropdown[aria-hidden="true"] {
-  display: none;
-}
-
-.custom-select-option {
-  display: block;
-  width: 100%;
-  padding: 7px 12px;
-  background: none;
-  border: none;
-  color: var(--text-secondary);
-  font-size: 11px;
-  font-family: inherit;
-  font-weight: 500;
-  text-align: left;
-  cursor: pointer;
-  transition: background 0.15s, color 0.15s;
-  white-space: nowrap;
-}
-
-.custom-select-option:hover {
-  background: var(--bg-glass-hover);
-  color: var(--text-primary);
-}
-
-.custom-select-option.selected {
-  color: var(--accent);
-  background: rgba(255, 69, 0, 0.08);
-}
-
-.pill-toggle {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  height: 26px;
-  padding: 0 10px;
-  background-color: var(--bg-glass);
-  border: 1px solid var(--border-color);
-  border-radius: 16px;
-  color: var(--text-secondary);
-  font-size: 11px;
-  font-family: inherit;
-  font-weight: 500;
-  cursor: pointer;
-  transition: var(--transition);
-  white-space: nowrap;
-  flex-shrink: 0;
-}
-
-.pill-toggle:hover {
-  border-color: rgba(255, 255, 255, 0.2);
-  color: var(--text-primary);
-  background-color: var(--bg-glass-hover);
-}
-
-.pill-toggle.active {
-  background-color: rgba(255, 69, 0, 0.15);
-  border-color: rgba(255, 69, 0, 0.5);
-  color: var(--accent);
-  box-shadow: 0 0 8px rgba(255, 69, 0, 0.18);
+  border-color: var(--border-strong);
+  background-color: var(--surface-3);
+  color: var(--text);
 }
 
 /* ── Advanced Filters (Collapsible) ───────────────────────── */
@@ -786,7 +989,7 @@ body::-webkit-scrollbar-thumb:hover {
 .advanced-filters {
   display: grid;
   grid-template-rows: 0fr;
-  transition: grid-template-rows 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  transition: grid-template-rows var(--t-med) var(--ease);
 }
 
 .advanced-filters[aria-hidden="false"] {
@@ -797,7 +1000,7 @@ body::-webkit-scrollbar-thumb:hover {
   overflow: hidden;
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 12px;
 }
 
 .advanced-filters[aria-hidden="false"] .advanced-filters-inner {
@@ -832,34 +1035,78 @@ body::-webkit-scrollbar-thumb:hover {
 
 .adv-label {
   font-size: 12px;
-  color: var(--text-secondary);
+  color: var(--text-2);
   flex-shrink: 0;
 }
 
 .adv-number-input {
   width: 72px;
-  height: 26px;
+  height: 28px;
   padding: 0 8px;
-  background-color: var(--bg-glass);
-  border: 1px solid var(--border-color);
-  border-radius: 6px;
-  color: var(--text-primary);
+  background-color: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  color: var(--text);
   font-size: 12px;
   font-family: inherit;
+  font-variant-numeric: tabular-nums;
   text-align: right;
-  transition: var(--transition);
+  transition: border-color var(--t-fast) var(--ease), box-shadow var(--t-fast) var(--ease);
 }
 
 .adv-number-input:focus {
   outline: none;
   border-color: var(--accent);
+  box-shadow: var(--ring);
 }
 
 .adv-number-input::placeholder {
-  color: var(--text-muted);
+  color: var(--text-3);
 }
 
-/* ── Depth Cards (mini radio buttons) ────────────────────── */
+.adv-select,
+.adv-textarea {
+  width: 100%;
+  padding: 6px 8px;
+  background-color: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  color: var(--text);
+  font-size: 12px;
+  font-family: inherit;
+  transition: border-color var(--t-fast) var(--ease), background-color var(--t-fast) var(--ease), box-shadow var(--t-fast) var(--ease);
+}
+
+.adv-select {
+  max-width: 158px;
+  height: 28px;
+  padding: 0 8px;
+  cursor: pointer;
+}
+
+.adv-select:hover,
+.adv-textarea:hover {
+  border-color: var(--border-strong);
+}
+
+.adv-textarea {
+  min-height: 64px;
+  resize: vertical;
+  line-height: 1.4;
+}
+
+.adv-select:focus,
+.adv-textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: var(--ring);
+}
+
+.adv-textarea::placeholder {
+  color: var(--text-3);
+}
+
+/* ── Depth Mini Cards ─────────────────────────────────────── */
 
 .depth-cards-row {
   display: flex;
@@ -883,33 +1130,33 @@ body::-webkit-scrollbar-thumb:hover {
 
 .depth-card-mini span {
   display: block;
-  padding: 4px 8px;
-  background-color: var(--bg-glass);
-  border: 1px solid var(--border-color);
-  border-radius: 6px;
+  padding: 5px 8px;
+  background-color: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
   font-size: 10px;
   font-weight: 500;
-  color: var(--text-muted);
-  transition: var(--transition);
+  color: var(--text-3);
+  transition: color var(--t-fast) var(--ease), border-color var(--t-fast) var(--ease), background-color var(--t-fast) var(--ease);
   white-space: nowrap;
   cursor: pointer;
   user-select: none;
 }
 
 .depth-card-mini:hover span {
-  border-color: rgba(255, 255, 255, 0.2);
-  color: var(--text-secondary);
-  background-color: var(--bg-glass-hover);
+  border-color: var(--border-strong);
+  color: var(--text-2);
+  background-color: var(--surface-3);
 }
 
 .depth-card-mini input[type="radio"]:checked+span {
-  background-color: rgba(255, 69, 0, 0.15);
-  border-color: rgba(255, 69, 0, 0.5);
-  color: var(--accent);
-  box-shadow: 0 0 6px rgba(255, 69, 0, 0.15);
+  background-color: var(--accent-soft);
+  border-color: var(--accent-border);
+  color: var(--accent-bright);
+  font-weight: 600;
 }
 
-/* ── Toggle Row ───────────────────────────────────────────── */
+/* ── Toggle Rows & Switches ───────────────────────────────── */
 
 .toggle-row {
   display: flex;
@@ -920,23 +1167,26 @@ body::-webkit-scrollbar-thumb:hover {
 }
 
 .toggle-row.compact {
-  padding: 2px 0;
-  margin-top: 2px;
-  padding-top: 8px;
-  border-top: 1px solid var(--border-color);
+  padding: 8px 0 0;
+  margin-top: 0;
+  border-top: 1px solid var(--border);
+}
+
+.privacy-toggle.compact {
+  border-top: none;
+  padding-top: 4px;
 }
 
 .toggle-label {
   font-size: 12px;
-  color: var(--text-secondary);
+  color: var(--text-2);
 }
-
-/* ── Toggle Switch ────────────────────────────────────────── */
 
 .toggle-switch {
   position: relative;
   width: 40px;
   height: 22px;
+  flex-shrink: 0;
 }
 
 .toggle-switch input {
@@ -949,10 +1199,10 @@ body::-webkit-scrollbar-thumb:hover {
   position: absolute;
   cursor: pointer;
   inset: 0;
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-color);
-  border-radius: 22px;
-  transition: var(--transition);
+  background: var(--surface-3);
+  border: 1px solid var(--border);
+  border-radius: var(--r-full);
+  transition: background var(--t-fast) var(--ease), border-color var(--t-fast) var(--ease);
 }
 
 .toggle-slider::before {
@@ -962,28 +1212,24 @@ body::-webkit-scrollbar-thumb:hover {
   width: 16px;
   left: 2px;
   bottom: 2px;
-  background: var(--text-secondary);
+  background: #fff;
+  box-shadow: var(--shadow-sm);
   border-radius: 50%;
-  transition: var(--transition);
+  transition: transform var(--t-fast) var(--ease);
 }
 
 .toggle-switch input:checked+.toggle-slider {
-  background: var(--accent);
-  border-color: var(--accent);
+  background: var(--accent-grad);
+  border-color: transparent;
 }
 
 .toggle-switch input:checked+.toggle-slider::before {
   transform: translateX(18px);
-  background: white;
 }
 
 .toggle-switch.small {
   width: 32px;
   height: 18px;
-}
-
-.toggle-switch.small .toggle-slider {
-  border-radius: 18px;
 }
 
 .toggle-switch.small .toggle-slider::before {
@@ -997,136 +1243,33 @@ body::-webkit-scrollbar-thumb:hover {
   transform: translateX(14px);
 }
 
-/* ── Action Button ────────────────────────────────────────── */
-
-.btn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  padding: 11px 16px;
-  border: none;
-  border-radius: var(--radius-sm);
-  font-size: 13px;
-  font-weight: 600;
-  cursor: pointer;
-  transition: var(--transition);
-}
-
-.btn:active {
-  transform: scale(0.98);
-}
-
-.btn-primary {
-  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-hover) 50%, #ff6b3d 100%);
-  background-size: 200% 200%;
-  color: white;
-  box-shadow: 0 4px 16px var(--accent-glow), inset 0 1px 0 rgba(255, 255, 255, 0.2);
-  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
-}
-
-.btn-primary:hover {
-  background-position: 100% 0;
-  box-shadow: 0 6px 24px var(--accent-glow), 0 0 30px var(--accent-glow), inset 0 1px 0 rgba(255, 255, 255, 0.2);
-  transform: translateY(-2px);
-}
-
-.btn-danger {
-  background: linear-gradient(135deg, var(--error), #dc2626);
-  color: white;
-}
-
-.btn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-  transform: none;
-}
-
-.btn-icon {
-  width: 18px;
-  height: 18px;
-}
-
-/* ── Entry Animation ──────────────────────────────────────── */
-
-@keyframes slideUpFade {
-  0% {
-    opacity: 0;
-    transform: translateY(10px) scale(0.98);
-  }
-
-  100% {
-    opacity: 1;
-    transform: translateY(0) scale(1);
-  }
-}
-
-.popup-container {
-  animation: slideUpFade 0.4s cubic-bezier(0.2, 0.8, 0.2, 1) backwards;
-}
-
-/* ── Upgrade controls ───────────────────────────────────── */
-.adv-select,
-.adv-textarea {
-  width: 100%;
-  padding: 7px 9px;
-  background-color: var(--bg-glass);
-  border: 1px solid var(--border-color);
-  border-radius: 6px;
-  color: var(--text-primary);
-  font-size: 12px;
-  font-family: inherit;
-  transition: var(--transition);
-}
-
-.adv-select {
-  max-width: 158px;
-  height: 30px;
-}
-
-.adv-textarea {
-  min-height: 62px;
-  resize: vertical;
-  line-height: 1.4;
-}
-
-.adv-select:focus,
-.adv-textarea:focus {
-  outline: none;
-  border-color: var(--accent);
-  box-shadow: 0 0 0 2px rgba(255, 69, 0, 0.1);
-}
-
-.adv-textarea::placeholder {
-  color: var(--text-muted);
-}
-
 /* ── Summary Result Card ──────────────────────────────────── */
+
 .summary-result-card {
   margin-top: 0;
-  background: rgba(21, 21, 23, 0.95);
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-sm);
-  padding: 16px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  padding: 12px;
   display: flex;
   flex-direction: column;
-  gap: 10px;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
-  animation: slideUpFade 0.3s cubic-bezier(0.2, 0.8, 0.2, 1) both;
+  gap: 8px;
+  box-shadow: var(--shadow-md), inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  animation: slideUpFade var(--t-med) var(--ease-out) both;
 }
 
 .summary-result-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  border-bottom: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--border);
   padding-bottom: 8px;
 }
 
 .summary-result-title {
   font-size: 13px;
-  font-weight: 700;
-  color: var(--text-primary);
+  font-weight: 600;
+  color: var(--text);
   display: flex;
   align-items: center;
   gap: 6px;
@@ -1134,28 +1277,28 @@ body::-webkit-scrollbar-thumb:hover {
 
 .summary-result-actions {
   display: flex;
-  gap: 6px;
+  gap: 4px;
 }
 
 .summary-action-btn {
-  background: var(--bg-glass);
-  border: 1px solid var(--border-color);
-  color: var(--text-secondary);
-  border-radius: 4px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  color: var(--text-2);
+  border-radius: 6px;
   width: 24px;
   height: 24px;
   display: flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  transition: var(--transition);
+  transition: color var(--t-fast) var(--ease), background var(--t-fast) var(--ease), border-color var(--t-fast) var(--ease);
   padding: 0;
 }
 
 .summary-action-btn:hover {
-  background: var(--bg-glass-hover);
-  color: var(--text-primary);
-  border-color: var(--text-secondary);
+  background: var(--surface-3);
+  color: var(--text);
+  border-color: var(--border-strong);
 }
 
 .summary-result-content-wrap {
@@ -1167,68 +1310,37 @@ body::-webkit-scrollbar-thumb:hover {
 .summary-result-text {
   font-size: 13px;
   line-height: 1.6;
-  color: var(--text-primary);
+  color: var(--text);
   white-space: pre-wrap;
   word-break: break-word;
 }
 
-/* Custom Scrollbar for summary content */
-.summary-result-content-wrap::-webkit-scrollbar {
-  width: 4px;
+/* ── Entry Animation ──────────────────────────────────────── */
+
+@keyframes slideUpFade {
+  0% {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
-.summary-result-content-wrap::-webkit-scrollbar-track {
-  background: transparent;
+.popup-container {
+  animation: slideUpFade 0.3s var(--ease-out) backwards;
 }
 
-.summary-result-content-wrap::-webkit-scrollbar-thumb {
-  background: var(--border-color);
-  border-radius: 2px;
-}
+/* ── Reduced Motion ───────────────────────────────────────── */
 
+@media (prefers-reduced-motion: reduce) {
 
-.summary-result-content-wrap::-webkit-scrollbar-thumb:hover {
-  background: var(--text-muted);
+  *,
+  *::before,
+  *::after {
+    animation: none !important;
+    transition: none !important;
+  }
 }
-
-/* Horizontal Export Chips */
-.export-chips-row {
-  display: flex;
-  gap: 8px;
-  width: 100%;
-}
-.export-chip {
-  flex: 1;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 5px;
-  height: 32px;
-  background: var(--bg-glass);
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-md);
-  color: var(--text-secondary);
-  font-size: 11px;
-  font-weight: 600;
-  cursor: pointer;
-  transition: var(--transition);
-}
-.export-chip:hover:not(.disabled) {
-  border-color: var(--accent);
-  color: var(--text-primary);
-  box-shadow: 0 0 8px var(--accent-glow);
-  transform: scale(1.02);
-}
-.export-chip.disabled {
-  opacity: 0.4;
-  cursor: not-allowed;
-  pointer-events: none;
-}
-.chip-icon {
-  font-size: 9px;
-  font-weight: 800;
-  background: rgba(255, 255, 255, 0.08);
-  padding: 2px 4px;
-  border-radius: 4px;
-}
-

--- a/src/popup.html
+++ b/src/popup.html
@@ -105,6 +105,20 @@
           </select>
           <button id="saveQuickPromptBtn" class="text-action-btn" type="button" disabled>Save quick prompt</button>
         </div>
+        <!-- Inline replacement for window.prompt(), which modern Chrome blocks in
+             action popups. Shown in place when saving a preset. -->
+        <div id="presetNameRow" class="preset-name-row" hidden>
+          <label class="preset-name-label" for="presetNameInput"
+            data-i18n="popup_preset_name_label">Preset name</label>
+          <input type="text" id="presetNameInput" class="preset-name-input" maxlength="60"
+            data-i18n-placeholder="popup_preset_name_placeholder" placeholder="Preset name">
+          <div class="preset-name-actions">
+            <button id="presetNameConfirmBtn" class="text-action-btn primary" type="button"
+              data-i18n="popup_preset_name_confirm">Save</button>
+            <button id="presetNameCancelBtn" class="text-action-btn" type="button"
+              data-i18n="popup_preset_name_cancel">Cancel</button>
+          </div>
+        </div>
       </div>
 
       <div class="send-mode-section">
@@ -126,7 +140,6 @@
               <option value="deepseek">DeepSeek</option>
               <option value="groq">Groq</option>
               <option value="custom">Custom</option>
-              <option value="local">Local AI (Gemini Nano)</option>
             </select>
           </label>
         </div>
@@ -177,45 +190,9 @@
           </button>
         </div>
       </div>
-
-      <!-- Local Summary Result Card -->
-      <div id="localSummaryResultCard" class="summary-result-card" style="display: none;">
-        <div class="summary-result-header">
-          <span class="summary-result-title">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="color: #3b82f6;">
-              <path d="m12 3-1.912 5.813a2 2 0 0 1-1.275 1.275L3 12l5.813 1.912a2 2 0 0 1 1.275 1.275L12 21l1.912-5.813a2 2 0 0 1 1.275-1.275L21 12l-5.813-1.912a2 2 0 0 1-1.275-1.275L12 3Z"/>
-            </svg>
-            Local Summary (Gemini Nano)
-          </span>
-          <div class="summary-result-actions">
-            <button id="copySummaryBtn" class="summary-action-btn" title="Copy to clipboard">
-              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
-                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
-              </svg>
-            </button>
-            <button id="exportSummaryBtn" class="summary-action-btn" title="Export as Markdown text file">
-              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
-                <polyline points="7 10 12 15 17 10"></polyline>
-                <line x1="12" y1="15" x2="12" y2="3"></line>
-              </svg>
-            </button>
-            <button id="closeSummaryBtn" class="summary-action-btn" title="Close summary">
-              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <line x1="18" y1="6" x2="6" y2="18"></line>
-                <line x1="6" y1="6" x2="18" y2="18"></line>
-              </svg>
-            </button>
-          </div>
-        </div>
-        <div class="summary-result-content-wrap">
-          <div id="localSummaryText" class="summary-result-text"></div>
-        </div>
-      </div>
     </div>
 
-    <div id="tabPaneFilters" class="tab-content hidden" role="tabpanel" aria-labelledby="tabFilters">
+    <div id="tabPaneFilters" class="tab-content hidden" role="tabpanel" aria-labelledby="tabFilters" hidden>
       <!-- Quick Filters -->
       <div class="filters-section">
         <div class="filters-header">
@@ -231,24 +208,18 @@
 
         <!-- Main pills row -->
         <div class="pills-row">
-          <div class="custom-select-wrap" id="minScoreWrap">
-            <button class="filter-select-compact custom-select-btn" id="filterMinScoreBtn"
-              aria-expanded="false" aria-haspopup="listbox">
-              <span id="filterMinScoreLabel">Any score</span>
-              <svg class="custom-select-arrow" width="10" height="6" viewBox="0 0 10 6" fill="none">
-                <path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"
-                  stroke-linejoin="round" />
-              </svg>
-            </button>
-            <div class="custom-select-dropdown" id="filterMinScoreDropdown" aria-hidden="true" role="listbox">
-              <button class="custom-select-option selected" data-value="0" role="option">Any score</button>
-              <button class="custom-select-option" data-value="5" role="option">5+ pts</button>
-              <button class="custom-select-option" data-value="10" role="option">10+ pts</button>
-              <button class="custom-select-option" data-value="25" role="option">25+ pts</button>
-              <button class="custom-select-option" data-value="50" role="option">50+ pts</button>
-              <button class="custom-select-option" data-value="100" role="option">100+ pts</button>
-            </div>
-          </div>
+          <!-- A native <select> here: it is a plain list of static options, so the
+               browser's own listbox gives correct keyboard and screen-reader
+               behaviour for free. -->
+          <select id="filterMinScore" class="filter-select-compact filter-select-native"
+            aria-label="Minimum comment score">
+            <option value="0">Any score</option>
+            <option value="5">5+ pts</option>
+            <option value="10">10+ pts</option>
+            <option value="25">25+ pts</option>
+            <option value="50">50+ pts</option>
+            <option value="100">100+ pts</option>
+          </select>
           <button id="filterHideBotsBtn" class="pill-toggle" data-key="hideBots">
             <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"
               stroke-linecap="round" stroke-linejoin="round">
@@ -262,7 +233,7 @@
         </div>
 
         <!-- Collapsible advanced panel -->
-        <div id="advancedFilters" class="advanced-filters" aria-hidden="true">
+        <div id="advancedFilters" class="advanced-filters" aria-hidden="true" inert>
           <div class="advanced-filters-inner">
             <!-- Top N -->
             <div class="adv-row">

--- a/src/popup.js
+++ b/src/popup.js
@@ -9,18 +9,60 @@ document.addEventListener('DOMContentLoaded', async () => {
   await initI18n();
   localizeHtmlPage();
 
-  document.querySelectorAll('.tab-trigger').forEach(btn => {
-    btn.addEventListener('click', () => {
-      document.querySelectorAll('.tab-trigger').forEach(b => {
-        b.classList.remove('active');
-        b.setAttribute('aria-selected', 'false');
-      });
-      document.querySelectorAll('.tab-content').forEach(c => c.classList.add('hidden'));
-      
-      btn.classList.add('active');
-      btn.setAttribute('aria-selected', 'true');
-      const targetPane = document.getElementById(btn.getAttribute('data-tab'));
-      if (targetPane) targetPane.classList.remove('hidden');
+  // ── Tabs ────────────────────────────────────────────────
+  const tabTriggers = Array.from(document.querySelectorAll('.tab-trigger'));
+
+  function activateTab(btn, { focus = false } = {}) {
+    tabTriggers.forEach(b => {
+      const selected = b === btn;
+      b.classList.toggle('active', selected);
+      b.setAttribute('aria-selected', selected ? 'true' : 'false');
+      // Roving tabindex: only the selected tab is a tab stop, so Tab moves past
+      // the tablist rather than through every tab in it.
+      b.tabIndex = selected ? 0 : -1;
+    });
+
+    document.querySelectorAll('.tab-content').forEach(c => {
+      c.classList.add('hidden');
+      // `hidden` alongside the class keeps the pane's children out of the tab
+      // order and out of the accessibility tree.
+      c.hidden = true;
+    });
+
+    const targetPane = document.getElementById(btn.getAttribute('data-tab'));
+    if (targetPane) {
+      targetPane.classList.remove('hidden');
+      targetPane.hidden = false;
+    }
+    if (focus) btn.focus();
+  }
+
+  tabTriggers.forEach((btn, index) => {
+    btn.tabIndex = btn.classList.contains('active') ? 0 : -1;
+    btn.addEventListener('click', () => activateTab(btn));
+
+    btn.addEventListener('keydown', (e) => {
+      let nextIndex = null;
+      switch (e.key) {
+        case 'ArrowRight':
+        case 'ArrowDown':
+          nextIndex = (index + 1) % tabTriggers.length;
+          break;
+        case 'ArrowLeft':
+        case 'ArrowUp':
+          nextIndex = (index - 1 + tabTriggers.length) % tabTriggers.length;
+          break;
+        case 'Home':
+          nextIndex = 0;
+          break;
+        case 'End':
+          nextIndex = tabTriggers.length - 1;
+          break;
+        default:
+          return;
+      }
+      e.preventDefault();
+      activateTab(tabTriggers[nextIndex], { focus: true });
     });
   });
 
@@ -31,11 +73,6 @@ document.addEventListener('DOMContentLoaded', async () => {
   const optionsBtn = document.getElementById('optionsBtn');
   const feedbackBtn = document.getElementById('feedbackBtn');
   const presetCards = document.querySelectorAll('.preset-card');
-  const localSummaryResultCard = document.getElementById('localSummaryResultCard');
-  const localSummaryText = document.getElementById('localSummaryText');
-  const copySummaryBtn = document.getElementById('copySummaryBtn');
-  const exportSummaryBtn = document.getElementById('exportSummaryBtn');
-  const closeSummaryBtn = document.getElementById('closeSummaryBtn');
   const quickPromptInput = document.getElementById('quickPrompt');
   const saveQuickPromptBtn = document.getElementById('saveQuickPromptBtn');
   const outputFormatSelect = document.getElementById('outputFormat');
@@ -65,48 +102,23 @@ document.addEventListener('DOMContentLoaded', async () => {
     });
   }
 
-  // ── Custom Min Score dropdown ───────────────────────────
+  // ── Min Score select ────────────────────────────────────
+  // Native <select>: the browser supplies keyboard nav, typeahead and screen
+  // reader semantics that the previous button + div listbox never implemented.
   let minScoreValue = 0;
 
-  const minScoreBtn = document.getElementById('filterMinScoreBtn');
-  const minScoreDropdown = document.getElementById('filterMinScoreDropdown');
-  const minScoreLabel = document.getElementById('filterMinScoreLabel');
-  const minScoreOptions = minScoreDropdown?.querySelectorAll('.custom-select-option');
+  const minScoreSelect = document.getElementById('filterMinScore');
 
-  function setMinScore(value, label) {
+  function setMinScore(value, { persist = true } = {}) {
     minScoreValue = value;
-    if (minScoreLabel) minScoreLabel.textContent = label;
-    minScoreOptions?.forEach(opt => {
-      opt.classList.toggle('selected', parseInt(opt.dataset.value, 10) === value);
-    });
-    chrome.storage.sync.set({ filterMinScore: value });
+    if (minScoreSelect) minScoreSelect.value = String(value);
+    if (persist) chrome.storage.sync.set({ filterMinScore: value });
   }
 
-  function closeMinScoreDropdown() {
-    minScoreBtn?.setAttribute('aria-expanded', 'false');
-    minScoreDropdown?.setAttribute('aria-hidden', 'true');
-  }
-
-  if (minScoreBtn && minScoreDropdown) {
-    minScoreBtn.addEventListener('click', (e) => {
-      e.stopPropagation();
-      const expanded = minScoreBtn.getAttribute('aria-expanded') === 'true';
-      minScoreBtn.setAttribute('aria-expanded', expanded ? 'false' : 'true');
-      minScoreDropdown.setAttribute('aria-hidden', expanded ? 'true' : 'false');
-    });
-
-    minScoreOptions?.forEach(opt => {
-      opt.addEventListener('click', () => {
-        setMinScore(parseInt(opt.dataset.value, 10), opt.textContent);
-        closeMinScoreDropdown();
-      });
-    });
-
-    // Close on outside click
-    document.addEventListener('click', (e) => {
-      if (!minScoreBtn.contains(e.target) && !minScoreDropdown.contains(e.target)) {
-        closeMinScoreDropdown();
-      }
+  if (minScoreSelect) {
+    minScoreSelect.addEventListener('change', (e) => {
+      setMinScore(parseInt(e.target.value, 10) || 0);
+      updateScrapeEstimate();
     });
   }
 
@@ -312,11 +324,12 @@ Data:
     selectedPreset = result.selectedPreset || 'summarize';
     updatePresetSelection(selectedPreset);
 
-    // Restore min score custom dropdown
+    // Restore min score
     if (result.filterMinScore) {
       const saved = parseInt(result.filterMinScore, 10);
-      const matchingOpt = minScoreDropdown?.querySelector(`[data-value="${saved}"]`);
-      if (matchingOpt) setMinScore(saved, matchingOpt.textContent);
+      const hasOption = Boolean(minScoreSelect?.querySelector(`option[value="${saved}"]`));
+      // Restoring is not a user edit, so it must not write back to storage.
+      if (hasOption) setMinScore(saved, { persist: false });
     }
 
     // Hide Bots pill
@@ -362,8 +375,7 @@ Data:
 
     // Advanced panel state
     if (result.advancedFiltersExpanded) {
-      expandFiltersBtn?.setAttribute('aria-expanded', 'true');
-      advancedFilters?.setAttribute('aria-hidden', 'false');
+      setAdvancedFiltersExpanded(true);
     }
 
     // Quick prompt - restore if saved
@@ -471,7 +483,7 @@ Data:
 
 
   function getProviderLabel(provider) {
-    return ({ gemini: 'Gemini', chatgpt: 'ChatGPT', claude: 'Claude', aistudio: 'AI Studio', deepseek: 'DeepSeek', groq: 'Groq', custom: 'Custom', local: 'Local AI' }[provider]) || 'Gemini';
+    return ({ gemini: 'Gemini', chatgpt: 'ChatGPT', claude: 'Claude', aistudio: 'AI Studio', deepseek: 'DeepSeek', groq: 'Groq', custom: 'Custom' }[provider]) || 'Gemini';
   }
 
   function getCheckedValue(name, fallback) {
@@ -479,14 +491,9 @@ Data:
   }
 
   function updateScrapeModeUi() {
-    const isLocal = popupProviderSelect?.value === 'local';
     const previewEnabled = (sendModeSelect?.value || 'preview') === 'preview';
     const btnText = scrapeBtn?.querySelector('.btn-text');
     if (!btnText) return;
-    if (isLocal) {
-      btnText.textContent = t('popup_btn_local_summary') || 'Summarize Locally';
-      return;
-    }
     if (currentBatchUrlCount > 0) {
       btnText.textContent = previewEnabled
         ? `Scrape ${currentBatchUrlCount} URLs & Preview`
@@ -499,18 +506,14 @@ Data:
   function updateBudgetTracker(tokenCount) {
     const bar = document.getElementById('budgetValueBar');
     const label = document.getElementById('budgetLabel');
-    if (!bar || !label) return;
+    if (!bar) return;
     
     const provider = popupProviderSelect?.value || 'gemini';
     let maxTokens = 128000;
     let safeLimit = 32000;
     let moderateLimit = 96000;
 
-    if (provider === 'local') {
-      maxTokens = 8000;
-      safeLimit = 2000;
-      moderateLimit = 6000;
-    } else if (provider === 'groq') {
+    if (provider === 'groq') {
       maxTokens = 131072;
       safeLimit = 30000;
       moderateLimit = 90000;
@@ -529,17 +532,32 @@ Data:
     
     bar.className = 'budget-bar-fill';
     const formattedCount = tokenCount.toLocaleString();
+    
+    let budgetText = '';
     if (tokenCount === 0) {
-      label.innerText = typeof t === 'function' ? t('popup_budget_initial') : 'Budget: 0 tokens';
+      budgetText = typeof t === 'function' ? t('popup_budget_initial') : 'Budget: 0 tokens';
     } else if (tokenCount < safeLimit) {
       bar.classList.add('safe');
-      label.innerText = typeof t === 'function' ? t('popup_budget_safe', [formattedCount]) : `Budget: ${formattedCount} tokens (Safe)`;
+      budgetText = typeof t === 'function' ? t('popup_budget_safe', [formattedCount]) : `Budget: ${formattedCount} tokens (Safe)`;
     } else if (tokenCount < moderateLimit) {
       bar.classList.add('moderate');
-      label.innerText = typeof t === 'function' ? t('popup_budget_moderate', [formattedCount]) : `Budget: ${formattedCount} tokens (Moderate)`;
+      budgetText = typeof t === 'function' ? t('popup_budget_moderate', [formattedCount]) : `Budget: ${formattedCount} tokens (Moderate)`;
     } else {
       bar.classList.add('large');
-      label.innerText = typeof t === 'function' ? t('popup_budget_large', [formattedCount]) : `Budget: ${formattedCount} tokens (Large)`;
+      budgetText = typeof t === 'function' ? t('popup_budget_large', [formattedCount]) : `Budget: ${formattedCount} tokens (Large)`;
+    }
+
+    if (label) {
+      label.innerText = budgetText;
+    }
+
+    if (scrapeEstimate) {
+      const baseText = scrapeEstimate.textContent.split(' · Budget:')[0];
+      if (tokenCount > 0) {
+        scrapeEstimate.textContent = `${baseText} · ${budgetText}`;
+      } else {
+        scrapeEstimate.textContent = `${baseText} · Budget: 0 tokens`;
+      }
     }
   }
 
@@ -619,32 +637,71 @@ Data:
     dontSaveThisScrape.addEventListener('change', updateScrapeEstimate);
   }
 
-  if (saveQuickPromptBtn) {
-    saveQuickPromptBtn.addEventListener('click', () => {
-      const raw = quickPromptInput?.value?.trim();
-      if (!raw) return;
-      const name = prompt('Preset name:', raw.slice(0, 42) || 'Quick prompt');
-      if (!name) return;
-      const template = raw.includes('{content}') ? raw : `${raw}\n\n{content}`;
-      const savedPreset = {
-        id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-        name,
-        category: 'custom',
-        createdAt: Date.now(),
-        template,
-        contextPreset: getCheckedValue('contextPresetPopup', 'balanced'),
-        trimStrategy: trimStrategySelect?.value || 'top',
-        mediaMode: mediaModeSelect?.value || 'attach',
-        outputFormat: outputFormatSelect?.value || 'auto'
-      };
-      chrome.storage.sync.get(['savedPromptPresets'], (result) => {
-        const presets = Array.isArray(result.savedPromptPresets) ? result.savedPromptPresets : [];
-        chrome.storage.sync.set({ savedPromptPresets: [savedPreset, ...presets].slice(0, 30) }, () => {
-          showToast('success', `Saved preset "${name}".`);
-        });
+  // ── Save quick prompt as preset ────────────────────────
+  // window.prompt() is blocked inside action popups in modern Chrome, so the name
+  // is collected with an inline row that opens in place instead.
+  const presetNameRow = document.getElementById('presetNameRow');
+  const presetNameInput = document.getElementById('presetNameInput');
+  const presetNameConfirmBtn = document.getElementById('presetNameConfirmBtn');
+  const presetNameCancelBtn = document.getElementById('presetNameCancelBtn');
+
+  function closePresetNameRow() {
+    if (!presetNameRow) return;
+    presetNameRow.hidden = true;
+    saveQuickPromptBtn?.focus();
+  }
+
+  function openPresetNameRow() {
+    const raw = quickPromptInput?.value?.trim();
+    if (!raw || !presetNameRow || !presetNameInput) return;
+    presetNameInput.value = raw.slice(0, 42) || (t('popup_preset_name_default') || 'Quick prompt');
+    presetNameRow.hidden = false;
+    presetNameInput.focus();
+    presetNameInput.select?.();
+  }
+
+  function commitPresetName() {
+    const raw = quickPromptInput?.value?.trim();
+    const name = presetNameInput?.value?.trim();
+    if (!raw || !name) return;
+
+    const template = raw.includes('{content}') ? raw : `${raw}\n\n{content}`;
+    const savedPreset = {
+      id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      name,
+      category: 'custom',
+      createdAt: Date.now(),
+      template,
+      contextPreset: getCheckedValue('contextPresetPopup', 'balanced'),
+      trimStrategy: trimStrategySelect?.value || 'top',
+      mediaMode: mediaModeSelect?.value || 'attach',
+      outputFormat: outputFormatSelect?.value || 'auto'
+    };
+    chrome.storage.sync.get(['savedPromptPresets'], (result) => {
+      const presets = Array.isArray(result.savedPromptPresets) ? result.savedPromptPresets : [];
+      chrome.storage.sync.set({ savedPromptPresets: [savedPreset, ...presets].slice(0, 30) }, () => {
+        showToast('success', `Saved preset "${name}".`);
       });
     });
+    closePresetNameRow();
   }
+
+  if (saveQuickPromptBtn) {
+    saveQuickPromptBtn.addEventListener('click', openPresetNameRow);
+  }
+
+  presetNameConfirmBtn?.addEventListener('click', commitPresetName);
+  presetNameCancelBtn?.addEventListener('click', closePresetNameRow);
+
+  presetNameInput?.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      commitPresetName();
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      closePresetNameRow();
+    }
+  });
 
   // ── Filter handlers ────────────────────────────────────
   if (filterHideBotsBtn) {
@@ -685,11 +742,20 @@ Data:
   }
 
   // ── Expand / Collapse advanced filters ─────────────────
+  // The panel animates via grid-template-rows, so `hidden` (display:none) would kill
+  // the transition. `inert` gives the same "not focusable, not announced" guarantee
+  // while leaving the element rendered.
+  function setAdvancedFiltersExpanded(expanded) {
+    expandFiltersBtn?.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+    if (!advancedFilters) return;
+    advancedFilters.setAttribute('aria-hidden', expanded ? 'false' : 'true');
+    advancedFilters.inert = !expanded;
+  }
+
   if (expandFiltersBtn) {
     expandFiltersBtn.addEventListener('click', () => {
       const expanded = expandFiltersBtn.getAttribute('aria-expanded') === 'true';
-      expandFiltersBtn.setAttribute('aria-expanded', expanded ? 'false' : 'true');
-      advancedFilters?.setAttribute('aria-hidden', expanded ? 'true' : 'false');
+      setAdvancedFiltersExpanded(!expanded);
       chrome.storage.sync.set({ advancedFiltersExpanded: !expanded });
     });
   }
@@ -754,42 +820,6 @@ Data:
     });
   }
 
-  function formatLocalSummaryHtml(text) {
-    if (!text) return '';
-    let escaped = text
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;');
-    escaped = escaped.replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>');
-    const lines = escaped.split('\n');
-    let inList = false;
-    const htmlParts = [];
-    
-    for (const line of lines) {
-      const trimmed = line.trim();
-      if (trimmed.startsWith('- ') || trimmed.startsWith('* ')) {
-        const content = trimmed.substring(2);
-        if (!inList) {
-          inList = true;
-          htmlParts.push('<ul>');
-        }
-        htmlParts.push('<li>' + content + '</li>');
-      } else {
-        if (inList) {
-          inList = false;
-          htmlParts.push('</ul>');
-        }
-        if (trimmed) {
-          htmlParts.push('<p>' + trimmed + '</p>');
-        }
-      }
-    }
-    if (inList) {
-      htmlParts.push('</ul>');
-    }
-    return htmlParts.join('');
-  }
-
   // ── Render popup state via toasts ──────────────────────
   function renderPopupState(state) {
     if (!state) return;
@@ -810,29 +840,21 @@ Data:
       scrapeBtn.style.display = 'flex';
       scrapeBtn.disabled = false;
 
-      const localOpt = popupProviderSelect?.querySelector('option[value="local"]');
-      if (localOpt) {
-        chrome.runtime.sendMessage({ action: 'checkLocalAiCapability' }, (response) => {
-          if (chrome.runtime.lastError || !response || !response.available) {
-            localOpt.disabled = true;
-            localOpt.text = t('popup_provider_local_disabled') || 'Local AI (Gemini Nano) - Disabled';
-          } else {
-            localOpt.disabled = false;
-            localOpt.text = t('popup_provider_local_enabled') || 'Local AI (Gemini Nano)';
-          }
-        });
-      }
-
       stopScrapeBtn.style.display = 'none';
+
+      // `status`/`phase` are the structured signal. The message sniffing below is a
+      // last-resort fallback for state objects that predate those fields.
+      const finished = state.status
+        ? state.status === 'complete'
+        : (state.phase === 'complete' ||
+          state.message?.includes('sent') ||
+          state.message?.includes('Content') ||
+          state.message?.includes('complete'));
 
       if (state.error) {
         dismissAllToasts();
         showToast('error', state.error, { dismiss: true });
-      } else if (
-        state.message?.includes('sent') ||
-        state.message?.includes('Content') ||
-        state.message?.includes('complete')
-      ) {
+      } else if (finished) {
         dismissAllToasts();
         showToast('success', t('popup_status_sent') || 'Content ready!');
       } else {
@@ -840,20 +862,6 @@ Data:
         dismissAllToasts();
       }
       checkExportAvailability();
-    }
-
-    if (state.summary !== undefined && state.summary !== null) {
-      if (localSummaryResultCard) {
-        localSummaryResultCard.style.display = 'flex';
-      }
-      if (localSummaryText) {
-        localSummaryText.innerHTML = formatLocalSummaryHtml(state.summary);
-        // Auto scroll to bottom during stream
-        const wrap = localSummaryResultCard.querySelector('.summary-result-content-wrap');
-        if (wrap) {
-          wrap.scrollTop = wrap.scrollHeight;
-        }
-      }
     }
   }
 
@@ -906,9 +914,6 @@ Data:
     scrapeBtn.addEventListener('click', () => {
       dismissAllToasts();
       scrapeBtn.disabled = true;
-      if (localSummaryResultCard) {
-        localSummaryResultCard.style.display = 'none';
-      }
 
       showToast('progress', t('popup_status_starting') || 'Starting...', {
         id: 'scraping-progress',
@@ -953,7 +958,6 @@ Data:
         };
 
         const selectedProvider = popupProviderSelect?.value || 'gemini';
-        const isLocal = selectedProvider === 'local';
         const directSendOnce = (sendModeSelect?.value || 'preview') === 'directOnce';
 
         chrome.storage.sync.set({
@@ -966,20 +970,15 @@ Data:
           lastBatchUrls: batchUrlsInput?.value?.trim() || ''
         });
 
-        if (isLocal && localSummaryText) {
-          localSummaryText.textContent = '';
-        }
-
         chrome.runtime.sendMessage({
           action: 'scrapeReddit',
           includeHidden: filters.includeHidden,
           filters,
           batchUrls,
           tabId: currentTab.id,
-          directSendOnce: isLocal ? false : directSendOnce,
-          showPromptPreview: isLocal ? false : !directSendOnce,
+          directSendOnce: directSendOnce,
+          showPromptPreview: !directSendOnce,
           selectedLlmProvider: selectedProvider,
-          localSummarize: isLocal,
           dataStorageOptionOverride: dontSaveThisScrape?.checked ? 'dontSave' : null
         }, (response) => {
           if (chrome.runtime.lastError) {
@@ -1145,59 +1144,6 @@ Data:
     });
   });
 
-  // ── Local AI capability check for dropdown option ──────
-  const localOption = popupProviderSelect?.querySelector('option[value="local"]');
-  if (localOption) {
-    chrome.runtime.sendMessage({ action: 'checkLocalAiCapability' }, (response) => {
-      if (chrome.runtime.lastError || !response || !response.available) {
-        localOption.disabled = true;
-        localOption.text = t('popup_provider_local_disabled') || 'Local AI (Gemini Nano) - Disabled';
-      } else {
-        localOption.disabled = false;
-        localOption.text = t('popup_provider_local_enabled') || 'Local AI (Gemini Nano)';
-      }
-    });
-  }
-
-  // ── Clipboard & Export listeners ─────────────────────────
-  if (copySummaryBtn && localSummaryText) {
-    copySummaryBtn.addEventListener('click', () => {
-      const textToCopy = localSummaryText.innerText || localSummaryText.textContent || '';
-      if (!textToCopy) return;
-      navigator.clipboard.writeText(textToCopy)
-        .then(() => {
-          showToast('success', 'Summary copied to clipboard!');
-        })
-        .catch(_err => {
-          showToast('error', 'Failed to copy summary.');
-        });
-    });
-  }
-
-  if (exportSummaryBtn && localSummaryText) {
-    exportSummaryBtn.addEventListener('click', () => {
-      const textToExport = localSummaryText.innerText || localSummaryText.textContent || '';
-      if (!textToExport) return;
-      
-      const blob = new Blob([textToExport], { type: 'text/markdown;charset=utf-8;' });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = `reddit-local-summary-${Date.now()}.md`;
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      URL.revokeObjectURL(url);
-      showToast('success', 'Summary exported!');
-    });
-  }
-
-  if (closeSummaryBtn && localSummaryResultCard) {
-    closeSummaryBtn.addEventListener('click', () => {
-      localSummaryResultCard.style.display = 'none';
-    });
-  }
-
   checkExportAvailability();
 
   // ── Get initial state ──────────────────────────────────
@@ -1210,15 +1156,9 @@ Data:
     // Only show toast if actively scraping; idle = clean UI
     if (stateResponse?.isActive) {
       renderPopupState(stateResponse);
-    } else if (stateResponse?.summary) {
-      // If we have a past local summary, display it!
-      renderPopupState(stateResponse);
     }
   });
 
-  if (globalThis.R2ATiktokenPromise) {
-    globalThis.R2ATiktokenPromise.then(() => {
-      updateScrapeEstimate();
-    });
-  }
+  // The popup shows an approximate budget only, so it deliberately does not load
+  // the 1MB tokenizer table; estimatePromptStats falls back to length / 4 here.
 });

--- a/src/preview.css
+++ b/src/preview.css
@@ -1,86 +1,306 @@
+/* Reddit to AI — Prompt Preview page ("Ember" design system) */
+
 :root {
-  --bg: #0d0d0d;
-  --card: rgba(39, 39, 42, 0.72);
-  --glass: rgba(255, 255, 255, 0.04);
-  --glass-hover: rgba(255, 255, 255, 0.08);
-  --border: rgba(255, 255, 255, 0.1);
-  --text: #ffffff;
-  --muted: #a0a0a0;
-  --dim: #737373;
+  /* Surfaces */
+  --bg: #09090b;
+  --surface: #121214;
+  --surface-2: #1a1a1e;
+  --surface-3: #232329;
+  --overlay: rgba(9, 9, 11, 0.72);
+
+  /* Borders */
+  --border: rgba(255, 255, 255, 0.07);
+  --border-strong: rgba(255, 255, 255, 0.14);
+
+  /* Text */
+  --text: #f4f4f5;
+  --text-2: #a1a1aa;
+  --text-3: #63636b;
+
+  /* Brand */
   --accent: #ff4500;
-  --accent-hover: #ff5f24;
-  --success: #10b981;
-  --warning: #f59e0b;
-  --danger: #ef4444;
-  --radius: 16px;
+  --accent-bright: #ff6a2b;
+  --accent-grad: linear-gradient(135deg, #ff4500 0%, #ff6a2b 100%);
+  --accent-soft: rgba(255, 69, 0, 0.12);
+  --accent-border: rgba(255, 69, 0, 0.35);
+  --accent-glow: rgba(255, 69, 0, 0.25);
+
+  /* Status */
+  --success: #34d399;
+  --warning: #fbbf24;
+  --danger: #f87171;
+  --info: #60a5fa;
+
+  /* Shape */
+  --r-sm: 8px;
+  --r-md: 12px;
+  --r-lg: 16px;
+  --r-full: 999px;
+
+  /* Elevation */
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+  --shadow-md: 0 8px 24px rgba(0, 0, 0, 0.45);
+  --shadow-lg: 0 16px 48px rgba(0, 0, 0, 0.55);
+
+  /* Motion */
+  --ease: cubic-bezier(0.4, 0, 0.2, 1);
+  --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+  --t-fast: 0.15s;
+  --t-med: 0.25s;
+
+  /* Focus */
+  --ring: 0 0 0 3px rgba(255, 69, 0, 0.28);
 }
 
+/* ── Base ─────────────────────────────────────────────────── */
 * { box-sizing: border-box; }
 
 body {
   margin: 0;
   min-height: 100vh;
-  background: radial-gradient(circle at top, rgba(255, 69, 0, 0.08), transparent 42%), var(--bg);
+  background:
+    radial-gradient(1000px 420px at 50% -180px, rgba(255, 69, 0, 0.06), transparent 70%),
+    var(--bg);
   color: var(--text);
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  font-size: 13px;
+  line-height: 1.5;
 }
 
 .preview-shell {
-  width: min(1180px, calc(100vw - 32px));
+  width: min(1200px, calc(100vw - 40px));
   margin: 0 auto;
-  padding: 28px 0;
+  padding: 32px 0 40px;
   display: flex;
   flex-direction: column;
   gap: 16px;
 }
 
+/* Two-column layout grid */
+.preview-container-layout {
+  display: grid;
+  grid-template-columns: 1fr 380px;
+  gap: 20px;
+  align-items: start;
+}
+
+.preview-main-content {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  min-width: 0;
+}
+
+.preview-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  position: sticky;
+  top: 20px;
+}
+
+/* Sidebar Adaptations */
+.preview-sidebar .controls-grid {
+  grid-template-columns: 1fr;
+  gap: 16px;
+}
+
+.preview-sidebar .summary-card {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 12px;
+}
+
+.preview-sidebar .budget-top {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 16px;
+}
+
+.preview-sidebar .budget-stats {
+  grid-template-columns: repeat(2, 1fr);
+  gap: 8px;
+}
+
+/* Card base */
 .preview-header,
 .summary-card,
 .budget-card,
 .controls-grid,
 .notice-card,
+.comments-tree-card,
 .editor-card,
+.api-card,
 .footer-card {
-  background: var(--card);
+  background: var(--surface);
   border: 1px solid var(--border);
-  border-radius: var(--radius);
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.22);
-  backdrop-filter: blur(14px);
+  border-radius: var(--r-lg);
+  box-shadow: var(--shadow-sm), inset 0 1px 0 rgba(255, 255, 255, 0.04);
 }
 
-.preview-header {
-  padding: 22px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 20px;
-}
-
+/* ── Typography ───────────────────────────────────────────── */
 .eyebrow {
-  color: var(--accent);
+  color: var(--text-3);
   text-transform: uppercase;
-  font-size: 12px;
-  letter-spacing: 0.08em;
-  font-weight: 700;
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  font-weight: 600;
 }
 
 h1 {
-  margin: 4px 0;
-  font-size: 30px;
-  letter-spacing: -0.04em;
+  margin: 6px 0 4px;
+  font-size: 26px;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  line-height: 1.15;
 }
 
-p { color: var(--muted); margin: 0; }
+h2 {
+  margin: 4px 0;
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+p { color: var(--text-2); margin: 0; }
+
+/* ── Header ───────────────────────────────────────────────── */
+.preview-header {
+  padding: 24px;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.preview-header .eyebrow { color: var(--accent-bright); }
+
+#threadMeta { font-size: 13px; color: var(--text-2); }
 
 .header-actions {
   display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 10px;
+  flex-shrink: 0;
+}
+
+.action-row {
+  display: flex;
+  align-items: center;
   gap: 8px;
   flex-wrap: wrap;
   justify-content: flex-end;
 }
 
+/* ── Buttons ──────────────────────────────────────────────── */
+.btn {
+  appearance: none;
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  padding: 9px 14px;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  color: var(--text);
+  background: var(--surface-2);
+  transition: background var(--t-fast) var(--ease),
+              border-color var(--t-fast) var(--ease),
+              color var(--t-fast) var(--ease),
+              box-shadow var(--t-fast) var(--ease),
+              transform var(--t-fast) var(--ease);
+}
+
+.btn:hover { background: var(--surface-3); border-color: var(--border-strong); }
+.btn:active { transform: scale(0.98); }
+.btn:disabled { cursor: not-allowed; opacity: 0.5; transform: none; }
+
+.btn.primary {
+  background: var(--accent-grad);
+  border-color: transparent;
+  color: #ffffff;
+  padding: 9px 18px;
+  box-shadow: var(--shadow-sm);
+}
+.btn.primary:hover {
+  filter: brightness(1.08);
+  box-shadow: 0 4px 20px var(--accent-glow);
+}
+
+.btn.secondary { color: var(--text); }
+
+.btn.ghost {
+  color: var(--text-2);
+  background: transparent;
+  border-color: transparent;
+}
+.btn.ghost:hover {
+  color: var(--text);
+  background: var(--surface-2);
+  border-color: var(--border);
+}
+
+.btn.tertiary {
+  background: transparent;
+  border-color: transparent;
+  color: var(--text-3);
+  font-weight: 500;
+  padding: 9px 10px;
+}
+.btn.tertiary:hover { color: var(--text-2); background: var(--surface-2); }
+
+/* ── Export chips ─────────────────────────────────────────── */
+.export-chips-row {
+  display: flex;
+  gap: 6px;
+}
+
+.export-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 34px;
+  padding: 0 12px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--r-full);
+  color: var(--text-2);
+  font: inherit;
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--t-fast) var(--ease),
+              border-color var(--t-fast) var(--ease),
+              color var(--t-fast) var(--ease),
+              box-shadow var(--t-fast) var(--ease);
+}
+.export-chip:hover:not(.disabled):not(:disabled) {
+  border-color: var(--accent-border);
+  color: var(--text);
+  background: var(--surface-3);
+}
+.export-chip.disabled,
+.export-chip:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+.chip-icon {
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  background: var(--accent-soft);
+  color: var(--accent-bright);
+  padding: 2px 5px;
+  border-radius: 4px;
+  font-family: ui-monospace, 'SF Mono', SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+/* ── Summary card ─────────────────────────────────────────── */
 .summary-card {
-  padding: 14px 16px;
+  padding: 16px 20px;
   display: flex;
   justify-content: space-between;
   gap: 16px;
@@ -90,214 +310,248 @@ p { color: var(--muted); margin: 0; }
 .summary-pills {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: 6px;
   margin-top: 8px;
 }
 
 .summary-pill {
   display: inline-flex;
   align-items: center;
-  min-height: 28px;
-  padding: 5px 9px;
-  border-radius: 999px;
+  min-height: 26px;
+  padding: 4px 10px;
+  border-radius: var(--r-full);
   border: 1px solid var(--border);
-  background: var(--glass);
-  color: var(--muted);
+  background: var(--surface-2);
+  color: var(--text-2);
   font-size: 12px;
-  font-weight: 700;
+  font-weight: 500;
 }
 
 .inline-toggle {
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  color: var(--muted);
+  color: var(--text-2);
   font-size: 13px;
-  font-weight: 700;
+  font-weight: 500;
   white-space: nowrap;
-}
-
-.btn {
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  padding: 10px 14px;
-  font: inherit;
-  font-weight: 700;
   cursor: pointer;
-  color: var(--text);
-  background: var(--glass);
-  transition: transform 0.16s ease, background 0.16s ease, border-color 0.16s ease;
 }
 
-.btn:hover { transform: translateY(-1px); background: var(--glass-hover); }
-.btn:disabled { cursor: not-allowed; opacity: 0.55; transform: none; }
-.btn.primary { background: var(--accent); border-color: var(--accent); }
-.btn.primary:hover { background: var(--accent-hover); }
-.btn.secondary { color: var(--text); }
-.btn.ghost { color: var(--muted); background: transparent; }
+.inline-toggle input[type="checkbox"] {
+  width: 15px;
+  height: 15px;
+  cursor: pointer;
+  accent-color: var(--accent);
+}
 
-.budget-card { padding: 18px; }
-.budget-top { display: flex; justify-content: space-between; gap: 24px; align-items: center; }
-#warningLabel { display: block; margin: 4px 0; font-size: 20px; }
-.budget-stats { display: grid; grid-template-columns: repeat(4, minmax(96px, 1fr)); gap: 10px; }
-.budget-stats div { background: var(--glass); border: 1px solid var(--border); border-radius: 12px; padding: 10px; }
-.budget-stats strong { display: block; font-size: 20px; }
-.budget-stats span { display: block; color: var(--muted); font-size: 12px; }
-.meter-track { height: 10px; margin-top: 16px; background: rgba(255,255,255,0.08); border-radius: 999px; overflow: hidden; }
-.meter-fill { height: 100%; width: 0; background: var(--success); transition: width 0.2s ease, background 0.2s ease; }
-.budget-card.medium .meter-fill { background: var(--warning); }
+/* ── Budget card (the star) ───────────────────────────────── */
+.budget-card { padding: 24px; }
+
+.budget-top {
+  display: flex;
+  justify-content: space-between;
+  gap: 32px;
+  align-items: center;
+}
+
+#warningLabel {
+  display: block;
+  margin: 6px 0 4px;
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--success);
+  transition: color var(--t-med) var(--ease);
+}
+
+.budget-card.medium #warningLabel { color: var(--warning); }
+.budget-card.high #warningLabel,
+.budget-card.critical #warningLabel { color: var(--danger); }
+
+#warningMessage { font-size: 12px; color: var(--text-3); max-width: 420px; }
+
+.budget-stats {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(104px, 1fr));
+  gap: 8px;
+}
+
+.budget-stats div {
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  padding: 12px 14px;
+}
+
+.budget-stats strong {
+  display: block;
+  font-size: 24px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  font-variant-numeric: tabular-nums;
+  font-family: ui-monospace, 'SF Mono', SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+.budget-stats span {
+  display: block;
+  margin-top: 2px;
+  color: var(--text-3);
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+/* Meter */
+.meter-track {
+  height: 6px;
+  margin-top: 20px;
+  background: var(--surface-3);
+  border-radius: var(--r-full);
+  overflow: hidden;
+}
+
+.meter-fill {
+  height: 100%;
+  width: 0;
+  border-radius: var(--r-full);
+  background: linear-gradient(135deg, #10b981 0%, var(--success) 100%);
+  transition: width 0.35s var(--ease), background var(--t-med) var(--ease);
+  position: relative;
+  overflow: hidden;
+}
+
+/* Animated sheen sweeping across the fill */
+.meter-fill::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: repeating-linear-gradient(
+    90deg,
+    transparent 0px,
+    rgba(255, 255, 255, 0.18) 60px,
+    transparent 120px
+  );
+  background-size: 200px 100%;
+  animation: meterSheen 2.4s linear infinite;
+}
+
+@keyframes meterSheen {
+  from { background-position: 0 0; }
+  to { background-position: 200px 0; }
+}
+
+.budget-card.medium .meter-fill {
+  background: linear-gradient(135deg, #f59e0b 0%, var(--warning) 100%);
+}
 .budget-card.high .meter-fill,
-.budget-card.critical .meter-fill { background: var(--danger); }
+.budget-card.critical .meter-fill {
+  background: linear-gradient(135deg, #ef4444 0%, var(--danger) 100%);
+}
 
+/* ── Controls grid ────────────────────────────────────────── */
 .controls-grid {
-  padding: 16px;
+  padding: 20px;
   display: grid;
   grid-template-columns: repeat(5, minmax(0, 1fr));
-  gap: 12px;
+  gap: 14px;
 }
 
-.field { display: flex; flex-direction: column; gap: 8px; }
-.field span { color: var(--muted); font-size: 12px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em; }
-select, textarea {
+.field { display: flex; flex-direction: column; gap: 6px; }
+
+.field > span {
+  color: var(--text-3);
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+select {
   width: 100%;
+  height: 38px;
+  padding: 0 10px;
   border: 1px solid var(--border);
-  border-radius: 12px;
-  background: rgba(10, 10, 10, 0.76);
+  border-radius: var(--r-sm);
+  background: var(--surface-2);
   color: var(--text);
   font: inherit;
-}
-select { height: 42px; padding: 0 12px; }
-
-.notice-card {
-  padding: 16px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 18px;
-  border-color: rgba(245, 158, 11, 0.35);
-  background: rgba(245, 158, 11, 0.1);
-}
-
-.editor-card { overflow: hidden; }
-.editor-toolbar {
-  min-height: 48px;
-  padding: 0 16px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  border-bottom: 1px solid var(--border);
-  gap: 12px;
-}
-.editor-tools {
-  display: flex;
-  gap: 12px;
-  align-items: center;
-  flex-wrap: wrap;
-  justify-content: flex-end;
-}
-#editHint { color: var(--muted); font-size: 13px; }
-.rebuild-notice {
-  color: var(--warning);
   font-size: 13px;
-  font-weight: 700;
-}
-.link-btn {
-  border: none;
-  background: transparent;
-  color: var(--accent);
-  font: inherit;
-  font-size: 13px;
-  font-weight: 700;
   cursor: pointer;
+  transition: border-color var(--t-fast) var(--ease), box-shadow var(--t-fast) var(--ease);
 }
-.link-btn:disabled {
-  color: var(--dim);
-  cursor: not-allowed;
-}
-#promptTextarea {
-  min-height: 56vh;
-  resize: vertical;
-  border: none;
-  border-radius: 0;
-  padding: 18px;
-  line-height: 1.55;
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace;
-  font-size: 13px;
-}
-#promptTextarea:focus, select:focus { outline: 2px solid rgba(255, 69, 0, 0.35); }
 
-.footer-card {
-  padding: 12px 16px;
+select:hover { border-color: var(--border-strong); }
+select:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: var(--ring);
+}
+
+/* ── Notice card ──────────────────────────────────────────── */
+.notice-card {
+  padding: 16px 20px;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  color: var(--muted);
+  gap: 20px;
+  border-color: rgba(251, 191, 36, 0.25);
+  background: rgba(251, 191, 36, 0.06);
 }
 
-.footer-actions {
-  display: flex;
-  gap: 8px;
-  flex-wrap: wrap;
-  justify-content: flex-end;
-}
+.notice-card strong { color: var(--warning); font-size: 13px; }
+.notice-card p { font-size: 12px; color: var(--text-2); margin-top: 2px; }
 
-@media (max-width: 900px) {
-  .preview-header, .summary-card, .budget-top, .notice-card { flex-direction: column; align-items: stretch; }
-  .controls-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-  .budget-stats { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-}
-
-@media (max-width: 560px) {
-  .controls-grid { grid-template-columns: 1fr; }
-  .header-actions { justify-content: flex-start; }
-}
-
+/* ── Comment tree ─────────────────────────────────────────── */
 .comments-tree-card {
-  padding: 18px;
+  padding: 20px;
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 14px;
 }
 
 .comments-tree-header {
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  align-items: flex-start;
   gap: 16px;
 }
+
+.comments-tree-header p { font-size: 12px; color: var(--text-3); max-width: 520px; }
 
 .comments-tree-actions {
   display: flex;
   gap: 8px;
+  flex-shrink: 0;
 }
 
 .tree-container {
-  max-height: 400px;
+  max-height: 420px;
   overflow-y: auto;
-  background: rgba(10, 10, 10, 0.4);
+  background: var(--surface-2);
   border: 1px solid var(--border);
-  border-radius: 12px;
-  padding: 16px;
+  border-radius: var(--r-md);
+  padding: 12px 16px;
 }
 
 .comment-node {
-  margin-left: 16px;
-  margin-top: 8px;
+  margin-left: 18px;
+  margin-top: 2px;
   position: relative;
 }
 
-.comment-node:first-child {
-  margin-top: 0;
-}
+.comment-node:first-child { margin-top: 0; }
 
 .comment-node::before {
   content: "";
   position: absolute;
-  left: -8px;
+  left: -10px;
   top: 0;
   bottom: 0;
   width: 1px;
-  background: var(--border);
+  background: var(--border-strong);
+  opacity: 0.6;
 }
 
 .comment-node[open] > .comment-summary::before {
@@ -310,123 +564,409 @@ select { height: 42px; padding: 0 12px; }
   display: flex;
   align-items: center;
   gap: 8px;
-  font-size: 14px;
-  padding: 4px 0;
+  font-size: 13px;
+  padding: 5px 8px;
+  margin: 0 -8px;
+  border-radius: var(--r-sm);
   user-select: none;
+  transition: background var(--t-fast) var(--ease);
 }
 
-.comment-summary::-webkit-details-marker {
-  display: none;
-}
+.comment-summary:hover { background: var(--surface-3); }
+
+.comment-summary::-webkit-details-marker { display: none; }
 
 .comment-summary::before {
   content: "▶";
-  font-size: 10px;
-  color: var(--muted);
-  transition: transform 0.15s ease;
+  font-size: 9px;
+  color: var(--text-3);
+  transition: transform var(--t-fast) var(--ease);
   display: inline-block;
+  flex-shrink: 0;
 }
 
 .comment-leaf {
-  margin-left: 16px;
-  margin-top: 8px;
+  margin-left: 18px;
+  margin-top: 2px;
   display: flex;
   align-items: center;
   gap: 8px;
-  font-size: 14px;
-  padding: 4px 0;
+  font-size: 13px;
+  padding: 5px 8px;
+  border-radius: var(--r-sm);
   position: relative;
+  transition: background var(--t-fast) var(--ease);
 }
+
+.comment-leaf:hover { background: var(--surface-3); }
 
 .comment-leaf::before {
   content: "";
   position: absolute;
-  left: -8px;
+  left: -10px;
   top: 0;
   bottom: 0;
   width: 1px;
-  background: var(--border);
+  background: var(--border-strong);
+  opacity: 0.6;
 }
 
 .comment-checkbox {
-  width: 16px;
-  height: 16px;
+  width: 15px;
+  height: 15px;
   cursor: pointer;
   accent-color: var(--accent);
+  flex-shrink: 0;
 }
 
-.comment-checkbox:disabled {
-  cursor: not-allowed;
-  opacity: 0.5;
-}
+.comment-checkbox:disabled { cursor: not-allowed; opacity: 0.45; }
 
 .comment-meta {
   font-weight: 600;
   color: var(--text);
+  white-space: nowrap;
 }
 
-.comment-meta .author {
-  color: var(--accent);
-}
+.comment-meta .author { color: var(--accent-bright); }
 
 .comment-meta .score {
-  color: var(--muted);
-  font-size: 12px;
+  color: var(--text-3);
+  font-size: 11px;
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
 }
 
 .comment-text-snippet {
-  color: var(--muted);
-  font-style: italic;
+  color: var(--text-2);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 600px;
+  font-size: 12px;
 }
 
 .comment-checkbox:disabled + .comment-meta,
 .comment-checkbox:disabled ~ .comment-text-snippet {
-  color: var(--dim);
+  color: var(--text-3);
   text-decoration: line-through;
 }
 
-/* Horizontal Export Chips */
-.export-chips-row {
-  display: flex;
-  gap: 8px;
-  width: 100%;
-}
-.export-chip {
-  flex: 1;
+/* ── Editor card ──────────────────────────────────────────── */
+.editor-card { overflow: hidden; }
+
+.editor-toolbar {
+  min-height: 50px;
+  padding: 8px 20px;
   display: flex;
   align-items: center;
-  justify-content: center;
-  gap: 6px;
-  height: 38px;
-  background: var(--glass);
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  color: var(--muted);
-  font-size: 11px;
-  font-weight: 600;
-  cursor: pointer;
-  transition: transform 0.16s ease, background 0.16s ease, border-color 0.16s ease;
-}
-.export-chip:hover:not(.disabled) {
-  border-color: var(--accent);
-  color: var(--text);
-  box-shadow: 0 0 8px rgba(255, 69, 0, 0.3);
-  transform: scale(1.02);
-}
-.export-chip.disabled {
-  opacity: 0.4;
-  cursor: not-allowed;
-  pointer-events: none;
-}
-.chip-icon {
-  font-size: 9px;
-  font-weight: 800;
-  background: rgba(255, 255, 255, 0.08);
-  padding: 2px 4px;
-  border-radius: 4px;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--border);
+  gap: 12px;
+  background: var(--surface-2);
 }
 
+.editor-toolbar > strong { font-size: 13px; font-weight: 600; }
+
+.editor-tools {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+#editHint { color: var(--text-3); font-size: 12px; }
+
+.rebuild-notice {
+  color: var(--warning);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.link-btn {
+  border: none;
+  background: transparent;
+  color: var(--accent-bright);
+  font: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 4px 6px;
+  border-radius: var(--r-sm);
+  transition: color var(--t-fast) var(--ease), background var(--t-fast) var(--ease);
+}
+
+.link-btn:hover:not(:disabled) { background: var(--accent-soft); }
+.link-btn:disabled { color: var(--text-3); cursor: not-allowed; }
+
+#promptTextarea {
+  display: block;
+  width: 100%;
+  min-height: 56vh;
+  resize: vertical;
+  border: none;
+  border-radius: 0;
+  padding: 20px;
+  background: var(--surface);
+  color: var(--text);
+  line-height: 1.6;
+  font-family: ui-monospace, 'SF Mono', SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12.5px;
+  transition: box-shadow var(--t-fast) var(--ease);
+}
+
+#promptTextarea:focus {
+  outline: none;
+  box-shadow: inset 0 0 0 2px rgba(255, 69, 0, 0.28);
+}
+
+/* ── Footer bar ───────────────────────────────────────────── */
+.footer-card {
+  padding: 12px 20px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  color: var(--text-2);
+  position: sticky;
+  bottom: 12px;
+  background: var(--surface-2);
+  box-shadow: var(--shadow-md), inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+#statusText { font-size: 12px; color: var(--text-2); }
+
+.footer-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+/* ── Focus-visible ────────────────────────────────────────── */
+.btn:focus-visible,
+.export-chip:focus-visible,
+.link-btn:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+input[type="checkbox"]:focus-visible,
+.comment-summary:focus-visible {
+  outline: none;
+  box-shadow: var(--ring);
+}
+
+/* ── Scrollbars ───────────────────────────────────────────── */
+::-webkit-scrollbar { width: 6px; height: 6px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.12);
+  border-radius: var(--r-full);
+}
+::-webkit-scrollbar-thumb:hover { background: rgba(255, 255, 255, 0.22); }
+
+/* ── Responsive ───────────────────────────────────────────── */
+@media (max-width: 960px) {
+  .preview-container-layout {
+    grid-template-columns: 1fr;
+  }
+  .preview-sidebar {
+    position: static;
+  }
+  .preview-sidebar .controls-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .preview-sidebar .budget-stats {
+    grid-template-columns: repeat(4, minmax(104px, 1fr));
+  }
+  .preview-sidebar .summary-card,
+  .preview-sidebar .budget-top {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+}
+
+@media (max-width: 900px) {
+  .preview-header,
+  .notice-card,
+  .comments-tree-header { flex-direction: column; align-items: stretch; }
+  .header-actions { align-items: stretch; }
+  .action-row { justify-content: flex-start; }
+}
+
+@media (max-width: 560px) {
+  .preview-sidebar .controls-grid { grid-template-columns: 1fr; }
+  .preview-sidebar .budget-stats { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .preview-sidebar .summary-card,
+  .preview-sidebar .budget-top {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}
+
+/* ── Reduced motion ───────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation: none !important;
+    transition: none !important;
+  }
+}
+
+
+/* Author `display` declarations beat the UA stylesheet's `[hidden] { display: none }`
+   regardless of specificity, so any flex/grid card toggled via the `hidden` attribute
+   would stay visible without this guard. */
+[hidden] {
+  display: none !important;
+}
+
+/* ── Direct API mode ──────────────────────────────────────── */
+.api-card {
+  padding: 18px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.api-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 20px;
+  flex-wrap: wrap;
+}
+
+.api-header h2 {
+  margin: 4px 0 6px;
+  font-size: 16px;
+}
+
+.api-header p {
+  margin: 0;
+  color: var(--text-2);
+  font-size: 13px;
+  max-width: 52ch;
+}
+
+.api-controls {
+  display: flex;
+  align-items: flex-end;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.api-controls .field {
+  min-width: 190px;
+}
+
+.api-hint {
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  font-size: 13px;
+  color: var(--text-2);
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md, 8px);
+  padding: 10px 12px;
+}
+
+.api-loading {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 13px;
+  color: var(--text-2);
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md, 8px);
+  padding: 12px;
+}
+
+.api-loading strong {
+  margin-left: auto;
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+}
+
+.api-spinner {
+  width: 14px;
+  height: 14px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  border: 2px solid var(--border-strong);
+  border-top-color: var(--accent-bright);
+  animation: api-spin 0.8s linear infinite;
+}
+
+@keyframes api-spin {
+  to { transform: rotate(360deg); }
+}
+
+/* Users who ask for reduced motion get a static indicator instead of a spinner. */
+@media (prefers-reduced-motion: reduce) {
+  .api-spinner { animation: none; }
+}
+
+.api-error {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  background: rgba(248, 113, 113, 0.08);
+  border: 1px solid rgba(248, 113, 113, 0.35);
+  border-radius: var(--r-md, 8px);
+  padding: 12px;
+}
+
+.api-error p {
+  margin: 0;
+  flex: 1 1 260px;
+  font-size: 13px;
+  color: var(--text);
+}
+
+.api-result {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.api-result-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.api-result-toolbar strong {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-3);
+}
+
+/* The response is inserted with textContent, so pre-wrap is what restores the
+   model's own line breaks and indentation without any HTML being parsed. */
+.api-response-text {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  max-height: 460px;
+  overflow-y: auto;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md, 8px);
+  padding: 14px 16px;
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--text);
+}
+
+.api-response-text:focus-visible {
+  outline: 2px solid var(--accent-bright);
+  outline-offset: 2px;
+}

--- a/src/preview.html
+++ b/src/preview.html
@@ -17,144 +17,197 @@
         <p id="threadMeta">Review, trim, edit, copy, export, or send the final prompt.</p>
       </div>
       <div class="header-actions">
-        <button id="backBtnTop" class="btn ghost">Back</button>
-        <button id="copyBtn" class="btn secondary">Copy</button>
-        <div class="export-chips-row">
-          <button type="button" class="export-chip" data-format="markdown" data-tooltip="tooltip_export_md" id="previewExportMd">
-            <span class="chip-icon">MD</span> Markdown
-          </button>
-          <button type="button" class="export-chip" data-format="json" data-tooltip="tooltip_export_json" id="previewExportJson">
-            <span class="chip-icon">JS</span> JSON
-          </button>
-          <button type="button" class="export-chip" data-format="csv" data-tooltip="tooltip_export_csv" id="previewExportCsv">
-            <span class="chip-icon">CS</span> CSV
-          </button>
+        <div class="action-row action-row-secondary">
+          <button id="backBtnTop" class="btn ghost">Back</button>
+          <button id="copyBtn" class="btn secondary">Copy</button>
+          <button id="savePresetBtn" class="btn secondary">Save preset</button>
+          <div class="export-chips-row">
+            <button type="button" class="export-chip" data-format="markdown" data-tooltip="tooltip_export_md" id="previewExportMd">
+              <span class="chip-icon">MD</span> Markdown
+            </button>
+            <button type="button" class="export-chip" data-format="json" data-tooltip="tooltip_export_json" id="previewExportJson">
+              <span class="chip-icon">JS</span> JSON
+            </button>
+            <button type="button" class="export-chip" data-format="csv" data-tooltip="tooltip_export_csv" id="previewExportCsv">
+              <span class="chip-icon">CS</span> CSV
+            </button>
+          </div>
         </div>
-        <button id="savePresetBtn" class="btn secondary">Save preset</button>
-        <button id="skipNextBtn" class="btn secondary">Send and skip preview next time</button>
-        <button id="sendBtn" class="btn primary">Send to AI</button>
+        <div class="action-row action-row-primary">
+          <button id="skipNextBtn" class="btn tertiary">Send and skip preview next time</button>
+          <button id="sendBtn" class="btn primary">Send to AI</button>
+        </div>
       </div>
     </header>
 
-    <section class="summary-card">
-      <div>
-        <span class="eyebrow">Prompt setup</span>
-        <div id="settingsSummary" class="summary-pills"></div>
-      </div>
-      <label class="inline-toggle">
-        <input type="checkbox" id="skipPreviewToggle">
-        <span>Always send directly</span>
-      </label>
-    </section>
+    <div class="preview-container-layout">
+      <!-- Main Content Workspace (Left Column) -->
+      <div class="preview-main-content">
+        <section id="missingCommentsCard" class="notice-card" hidden>
+          <div>
+            <strong>Some morechildren batches failed.</strong>
+            <p id="missingCommentsText">You can try to resume the missing comments before sending.</p>
+          </div>
+          <button id="resumeBtn" class="btn secondary">Resume missing comments</button>
+        </section>
 
-    <section class="budget-card" id="budgetCard">
-      <div class="budget-top">
-        <div>
-          <span class="eyebrow">AI prompt size</span>
-          <strong id="warningLabel">Calculating…</strong>
-          <p id="warningMessage">Preparing context budget.</p>
-        </div>
-        <div class="budget-stats">
-          <div><strong id="charCount">0</strong><span>characters</span></div>
-          <div><strong id="tokenCount">0</strong><span>est. tokens</span></div>
-          <div><strong id="commentCount">0</strong><span>comments</span></div>
-          <div><strong id="imageCount">0</strong><span>images</span></div>
-        </div>
-      </div>
-      <div class="meter-track"><div id="meterFill" class="meter-fill"></div></div>
-    </section>
+        <section class="comments-tree-card" id="commentsTreeCard">
+          <div class="comments-tree-header">
+            <div>
+              <span class="eyebrow">Interactive Comment Tree</span>
+              <h2>Comment Pruning</h2>
+              <p>Uncheck comments to exclude them from the AI prompt. Unchecking a comment automatically disables all its replies.</p>
+            </div>
+            <div class="comments-tree-actions">
+              <button id="selectAllCommentsBtn" class="btn secondary">Select All</button>
+              <button id="clearAllCommentsBtn" class="btn secondary">Clear All</button>
+            </div>
+          </div>
+          <div id="commentsTreeContainer" class="tree-container"></div>
+        </section>
 
-    <section class="controls-grid">
-      <label class="field">
-        <span>Context preset</span>
-        <select id="contextPresetSelect">
-          <option value="small">Small</option>
-          <option value="balanced">Balanced</option>
-          <option value="full">Full</option>
-          <option value="maxQuality">Max Quality</option>
-        </select>
-      </label>
-      <label class="field">
-        <span>Trim strategy</span>
-        <select id="trimStrategySelect">
-          <option value="top">Top scored</option>
-          <option value="controversial">Controversial</option>
-          <option value="op">OP replies</option>
-          <option value="flaired">Flaired users</option>
-          <option value="diverse">Diverse viewpoints</option>
-          <option value="newest">Newest</option>
-          <option value="longest">Longest helpful</option>
-        </select>
-      </label>
-      <label class="field">
-        <span>Media handling</span>
-        <select id="mediaModeSelect">
-          <option value="attach">Attach images + list URLs</option>
-          <option value="urls">List URLs only</option>
-          <option value="ignore">Ignore media</option>
-        </select>
-      </label>
-      <label class="field">
-        <span>AI platform</span>
-        <select id="providerSelect">
-          <option value="gemini">Gemini</option>
-          <option value="chatgpt">ChatGPT</option>
-          <option value="claude">Claude</option>
-          <option value="aistudio">AI Studio</option>
-          <option value="deepseek">DeepSeek</option>
-          <option value="groq">Groq</option>
-          <option value="custom">Custom</option>
-        </select>
-      </label>
-      <label class="field">
-        <span>Output format</span>
-        <select id="outputFormatSelect">
-          <option value="auto">Auto</option>
-          <option value="bullets">Bullets</option>
-          <option value="table">Table</option>
-          <option value="json">JSON</option>
-          <option value="prosCons">Pros / cons</option>
-          <option value="executive">Executive summary</option>
-        </select>
-      </label>
-    </section>
+        <section class="editor-card">
+          <div class="editor-toolbar">
+            <strong>Final prompt</strong>
+            <div class="editor-tools">
+              <span id="editHint">You can edit this text before sending.</span>
+              <span id="rebuildNotice" class="rebuild-notice" hidden>Settings changed. Your edited prompt was kept.</span>
+              <button id="applyRebuiltPromptBtn" class="link-btn" type="button" hidden>Apply rebuilt prompt</button>
+              <button id="keepEditsBtn" class="link-btn" type="button" hidden>Keep edits</button>
+              <button id="restorePromptBtn" class="link-btn" type="button" disabled>Restore generated prompt</button>
+            </div>
+          </div>
+          <textarea id="promptTextarea" spellcheck="true"></textarea>
+        </section>
 
-    <section id="missingCommentsCard" class="notice-card" hidden>
-      <div>
-        <strong>Some morechildren batches failed.</strong>
-        <p id="missingCommentsText">You can try to resume the missing comments before sending.</p>
-      </div>
-      <button id="resumeBtn" class="btn secondary">Resume missing comments</button>
-    </section>
+        <section class="api-card" id="apiCard">
+          <div class="api-header">
+            <div>
+              <span class="eyebrow" data-i18n="preview_api_eyebrow">Direct API</span>
+              <h2 data-i18n="preview_api_title">Send with your own API key</h2>
+              <p data-i18n="preview_api_description">Send the prompt straight to a provider and read the answer here, without opening an AI chat tab.</p>
+            </div>
+            <div class="api-controls">
+              <label class="field">
+                <span data-i18n="preview_api_provider_label">API provider</span>
+                <select id="apiProviderSelect"></select>
+              </label>
+              <button id="sendApiBtn" class="btn primary" type="button" data-i18n="preview_api_send">Send via API</button>
+            </div>
+          </div>
 
-    <section class="comments-tree-card" id="commentsTreeCard">
-      <div class="comments-tree-header">
-        <div>
-          <span class="eyebrow">Interactive Comment Tree</span>
-          <h2>Comment Pruning</h2>
-          <p>Uncheck comments to exclude them from the AI prompt. Unchecking a comment automatically disables all its replies.</p>
-        </div>
-        <div class="comments-tree-actions">
-          <button id="selectAllCommentsBtn" class="btn secondary">Select All</button>
-          <button id="clearAllCommentsBtn" class="btn secondary">Clear All</button>
-        </div>
-      </div>
-      <div id="commentsTreeContainer" class="tree-container"></div>
-    </section>
+          <p id="apiNotConfigured" class="api-hint" hidden>
+            <span id="apiNotConfiguredText" data-i18n="preview_api_no_key">No API key is configured for this provider.</span>
+            <button id="apiOpenOptionsBtn" class="link-btn" type="button" data-i18n="preview_api_open_options">Add a key in options</button>
+          </p>
 
-    <section class="editor-card">
-      <div class="editor-toolbar">
-        <strong>Final prompt</strong>
-        <div class="editor-tools">
-          <span id="editHint">You can edit this text before sending.</span>
-          <span id="rebuildNotice" class="rebuild-notice" hidden>Settings changed. Your edited prompt was kept.</span>
-          <button id="applyRebuiltPromptBtn" class="link-btn" type="button" hidden>Apply rebuilt prompt</button>
-          <button id="keepEditsBtn" class="link-btn" type="button" hidden>Keep edits</button>
-          <button id="restorePromptBtn" class="link-btn" type="button" disabled>Restore generated prompt</button>
-        </div>
+          <div id="apiLoading" class="api-loading" hidden>
+            <span class="api-spinner" aria-hidden="true"></span>
+            <span data-i18n="preview_api_loading">Waiting for the AI response…</span>
+            <strong id="apiElapsed">0s</strong>
+          </div>
+
+          <div id="apiError" class="api-error" role="alert" hidden>
+            <p id="apiErrorMessage"></p>
+            <button id="apiRetryBtn" class="btn secondary" type="button" data-i18n="preview_api_retry">Retry</button>
+          </div>
+
+          <div id="apiResult" class="api-result" hidden>
+            <div class="api-result-toolbar">
+              <strong id="apiResultMeta"></strong>
+              <button id="apiCopyBtn" class="btn secondary" type="button" data-i18n="preview_api_copy">Copy response</button>
+            </div>
+            <div id="apiResponseText" class="api-response-text" tabindex="0"></div>
+          </div>
+        </section>
       </div>
-      <textarea id="promptTextarea" spellcheck="true"></textarea>
-    </section>
+
+      <!-- Sidebar Controls & Stats (Right Column) -->
+      <aside class="preview-sidebar">
+        <section class="summary-card">
+          <div>
+            <span class="eyebrow">Prompt setup</span>
+            <div id="settingsSummary" class="summary-pills"></div>
+          </div>
+          <label class="inline-toggle">
+            <input type="checkbox" id="skipPreviewToggle">
+            <span>Always send directly</span>
+          </label>
+        </section>
+
+        <section class="budget-card" id="budgetCard">
+          <div class="budget-top">
+            <div>
+              <span class="eyebrow">AI prompt size</span>
+              <strong id="warningLabel">Calculating…</strong>
+              <p id="warningMessage">Preparing context budget.</p>
+            </div>
+            <div class="budget-stats">
+              <div><strong id="charCount">0</strong><span>characters</span></div>
+              <div><strong id="tokenCount">0</strong><span>est. tokens</span></div>
+              <div><strong id="commentCount">0</strong><span>comments</span></div>
+              <div><strong id="imageCount">0</strong><span>images</span></div>
+            </div>
+          </div>
+          <div class="meter-track"><div id="meterFill" class="meter-fill"></div></div>
+        </section>
+
+        <section class="controls-grid">
+          <label class="field">
+            <span>Context preset</span>
+            <select id="contextPresetSelect">
+              <option value="small">Small</option>
+              <option value="balanced">Balanced</option>
+              <option value="full">Full</option>
+              <option value="maxQuality">Max Quality</option>
+            </select>
+          </label>
+          <label class="field">
+            <span>Trim strategy</span>
+            <select id="trimStrategySelect">
+              <option value="top">Top scored</option>
+              <option value="controversial">Controversial</option>
+              <option value="op">OP replies</option>
+              <option value="flaired">Flaired users</option>
+              <option value="diverse">Diverse viewpoints</option>
+              <option value="newest">Newest</option>
+              <option value="longest">Longest helpful</option>
+            </select>
+          </label>
+          <label class="field">
+            <span>Media handling</span>
+            <select id="mediaModeSelect">
+              <option value="attach">Attach images + list URLs</option>
+              <option value="urls">List URLs only</option>
+              <option value="ignore">Ignore media</option>
+            </select>
+          </label>
+          <label class="field">
+            <span>AI platform</span>
+            <select id="providerSelect">
+              <option value="gemini">Gemini</option>
+              <option value="chatgpt">ChatGPT</option>
+              <option value="claude">Claude</option>
+              <option value="aistudio">AI Studio</option>
+              <option value="deepseek">DeepSeek</option>
+              <option value="groq">Groq</option>
+              <option value="custom">Custom</option>
+            </select>
+          </label>
+          <label class="field">
+            <span>Output format</span>
+            <select id="outputFormatSelect">
+              <option value="auto">Auto</option>
+              <option value="bullets">Bullets</option>
+              <option value="table">Table</option>
+              <option value="json">JSON</option>
+              <option value="prosCons">Pros / cons</option>
+              <option value="executive">Executive summary</option>
+            </select>
+          </label>
+        </section>
+      </aside>
+    </div>
 
     <section class="footer-card">
       <span id="statusText">Ready.</span>

--- a/src/preview.js
+++ b/src/preview.js
@@ -10,7 +10,11 @@ let previewState = {
   pendingRenderedData: null,
   pendingBuildOptions: null,
   sendInFlight: false,
-  hasCustomPruning: false
+  hasCustomPruning: false,
+  apiStatus: null,
+  apiInFlight: false,
+  apiTimer: null,
+  historyId: null
 };
 
 const els = {};
@@ -27,9 +31,12 @@ document.addEventListener('DOMContentLoaded', async () => {
   bindElements();
   bindEvents();
   loadPreviewData();
+  loadDirectApiStatus();
 
-  if (globalThis.R2ATiktokenPromise) {
-    globalThis.R2ATiktokenPromise.then(() => {
+  // The preview page is where exact token counts matter, so it triggers the lazy
+  // tokenizer load and refreshes the displayed count once the rank table is ready.
+  if (typeof globalThis.R2ATiktokenEnsure === 'function') {
+    globalThis.R2ATiktokenEnsure().then(() => {
       if (els.promptTextarea && (previewState.renderedData || previewState.data)) {
         updateBudget(els.promptTextarea.value, previewState.renderedData || previewState.data);
       }
@@ -72,6 +79,20 @@ function bindElements() {
   els.rebuildNotice = document.getElementById('rebuildNotice');
   els.applyRebuiltPromptBtn = document.getElementById('applyRebuiltPromptBtn');
   els.keepEditsBtn = document.getElementById('keepEditsBtn');
+  els.apiProviderSelect = document.getElementById('apiProviderSelect');
+  els.sendApiBtn = document.getElementById('sendApiBtn');
+  els.apiNotConfigured = document.getElementById('apiNotConfigured');
+  els.apiNotConfiguredText = document.getElementById('apiNotConfiguredText');
+  els.apiOpenOptionsBtn = document.getElementById('apiOpenOptionsBtn');
+  els.apiLoading = document.getElementById('apiLoading');
+  els.apiElapsed = document.getElementById('apiElapsed');
+  els.apiError = document.getElementById('apiError');
+  els.apiErrorMessage = document.getElementById('apiErrorMessage');
+  els.apiRetryBtn = document.getElementById('apiRetryBtn');
+  els.apiResult = document.getElementById('apiResult');
+  els.apiResultMeta = document.getElementById('apiResultMeta');
+  els.apiResponseText = document.getElementById('apiResponseText');
+  els.apiCopyBtn = document.getElementById('apiCopyBtn');
   els.commentsTreeContainer = document.getElementById('commentsTreeContainer');
   els.selectAllCommentsBtn = document.getElementById('selectAllCommentsBtn');
   els.clearAllCommentsBtn = document.getElementById('clearAllCommentsBtn');
@@ -134,6 +155,17 @@ function bindEvents() {
     toggleAllCheckboxes(false);
   });
   els.commentsTreeContainer?.addEventListener('change', handleCheckboxChange);
+
+  els.apiProviderSelect?.addEventListener('change', () => {
+    chrome.storage.local.set({ lastDirectApiProvider: els.apiProviderSelect.value });
+    updateApiAvailability();
+  });
+  els.sendApiBtn?.addEventListener('click', sendPromptViaApi);
+  els.apiRetryBtn?.addEventListener('click', sendPromptViaApi);
+  els.apiCopyBtn?.addEventListener('click', copyApiResponse);
+  els.apiOpenOptionsBtn?.addEventListener('click', () => {
+    chrome.runtime.openOptionsPage();
+  });
 }
 
 function setStatus(message) {
@@ -152,6 +184,7 @@ function loadPreviewData() {
 
     previewState.data = response.data;
     previewState.settings = response.settings || {};
+    previewState.historyId = response.historyId || null;
     previewState.template = previewState.settings.defaultPromptTemplate || 'Please analyze the following Reddit thread.\n\n{content}';
 
     els.contextPresetSelect.value = previewState.settings.contextPreset || 'balanced';
@@ -480,6 +513,183 @@ function sendPrompt() {
   });
 }
 
+// =====================
+// Direct API mode
+// =====================
+//
+// The response is rendered with textContent (never innerHTML): it is model output
+// built from untrusted Reddit text, so it is treated as data, not markup. CSS
+// `white-space: pre-wrap` is what preserves its line breaks and indentation.
+
+function loadDirectApiStatus() {
+  if (!els.apiProviderSelect) return;
+  chrome.runtime.sendMessage({ action: 'getDirectApiStatus' }, (response) => {
+    if (chrome.runtime.lastError || response?.error || !response?.providers) {
+      previewState.apiStatus = null;
+      updateApiAvailability();
+      return;
+    }
+    previewState.apiStatus = response.providers;
+    els.apiProviderSelect.innerHTML = '';
+    Object.values(response.providers).forEach(provider => {
+      const option = document.createElement('option');
+      option.value = provider.id;
+      // Built with textContent so a provider label can never inject markup.
+      option.textContent = provider.configured ? provider.label : `${provider.label} (no key)`;
+      els.apiProviderSelect.appendChild(option);
+    });
+
+    chrome.storage.local.get(['lastDirectApiProvider'], (stored) => {
+      const preferred = stored?.lastDirectApiProvider;
+      // Default to the first provider that actually has a key configured.
+      const firstConfigured = Object.values(response.providers).find(p => p.configured);
+      const chosen = (preferred && response.providers[preferred])
+        ? preferred
+        : (firstConfigured?.id || Object.keys(response.providers)[0]);
+      if (chosen) els.apiProviderSelect.value = chosen;
+      updateApiAvailability();
+    });
+  });
+}
+
+// A key added on the options page must take effect without reloading this tab:
+// the "Add a key in options" link would otherwise lead back to a still-disabled
+// button. An in-flight request is left alone so the refresh cannot re-enable
+// controls mid-send.
+if (typeof chrome !== 'undefined' && chrome.storage?.onChanged) {
+  chrome.storage.onChanged.addListener((changes, area) => {
+    if (area !== 'local' || !changes.directApiConfig) return;
+    if (previewState.apiInFlight) return;
+    loadDirectApiStatus();
+  });
+}
+
+function getSelectedApiProvider() {
+  const id = els.apiProviderSelect?.value;
+  if (!id || !previewState.apiStatus) return null;
+  return previewState.apiStatus[id] || null;
+}
+
+function updateApiAvailability() {
+  const provider = getSelectedApiProvider();
+  const configured = Boolean(provider?.configured);
+  if (els.sendApiBtn) els.sendApiBtn.disabled = !configured || previewState.apiInFlight;
+  if (els.apiNotConfigured) els.apiNotConfigured.hidden = configured;
+  if (!configured && provider && els.apiNotConfiguredText) {
+    els.apiNotConfiguredText.textContent =
+      t('preview_api_no_key_for', [provider.label]) || `No API key is configured for ${provider.label}.`;
+  }
+}
+
+function setApiInFlight(inFlight) {
+  previewState.apiInFlight = inFlight;
+  if (els.sendApiBtn) els.sendApiBtn.disabled = inFlight || !getSelectedApiProvider()?.configured;
+  if (els.apiRetryBtn) els.apiRetryBtn.disabled = inFlight;
+  if (els.apiProviderSelect) els.apiProviderSelect.disabled = inFlight;
+  if (els.apiLoading) els.apiLoading.hidden = !inFlight;
+
+  if (previewState.apiTimer) {
+    clearInterval(previewState.apiTimer);
+    previewState.apiTimer = null;
+  }
+  if (inFlight) {
+    const startedAt = Date.now();
+    if (els.apiElapsed) els.apiElapsed.textContent = '0s';
+    previewState.apiTimer = setInterval(() => {
+      const seconds = Math.floor((Date.now() - startedAt) / 1000);
+      if (els.apiElapsed) els.apiElapsed.textContent = `${seconds}s`;
+    }, 1000);
+  }
+}
+
+function showApiError(message, retryable) {
+  if (!els.apiError) return;
+  els.apiError.hidden = false;
+  const suffix = retryable
+    ? ` ${t('preview_api_retryable') || 'This looks temporary — try again in a moment.'}`
+    : '';
+  els.apiErrorMessage.textContent = `${message}${suffix}`;
+}
+
+function clearApiError() {
+  if (els.apiError) els.apiError.hidden = true;
+  if (els.apiErrorMessage) els.apiErrorMessage.textContent = '';
+}
+
+function sendPromptViaApi() {
+  if (previewState.apiInFlight) return;
+  const provider = getSelectedApiProvider();
+  if (!provider?.configured) {
+    updateApiAvailability();
+    return;
+  }
+  const promptText = els.promptTextarea?.value.trim() || '';
+  if (!promptText) {
+    showApiError(t('preview_api_empty_prompt') || 'Prompt is empty.', false);
+    return;
+  }
+
+  clearApiError();
+  if (els.apiResult) els.apiResult.hidden = true;
+  setApiInFlight(true);
+  setStatus(t('preview_api_status_sending') || 'Sending the prompt to the API…');
+
+  chrome.runtime.sendMessage({
+    action: 'sendPromptViaApi',
+    apiProvider: provider.id,
+    promptText,
+    historyId: previewState.historyId
+  }, (response) => {
+    setApiInFlight(false);
+    if (chrome.runtime.lastError || response?.error || !response?.response) {
+      const message = response?.error
+        || chrome.runtime.lastError?.message
+        || (t('preview_api_failed') || 'The API request failed.');
+      // A dropped message channel (worker torn down mid-request) is worth retrying.
+      const retryable = response?.retryable === true || Boolean(chrome.runtime.lastError);
+      showApiError(message, retryable);
+      setStatus(t('preview_api_status_failed') || 'API request failed.');
+      return;
+    }
+    renderApiResponse(response.response);
+  });
+}
+
+function renderApiResponse(result) {
+  if (!els.apiResult || !els.apiResponseText) return;
+  els.apiResult.hidden = false;
+
+  if (result.refused) {
+    els.apiResponseText.textContent =
+      t('preview_api_refused') || 'The provider declined to answer this request.';
+  } else if (!result.text) {
+    els.apiResponseText.textContent =
+      t('preview_api_empty_response') || 'The provider returned an empty response.';
+  } else {
+    // textContent, never innerHTML.
+    els.apiResponseText.textContent = result.text;
+  }
+
+  const seconds = Math.round((result.durationMs || 0) / 1000);
+  const parts = [result.model, `${seconds}s`];
+  if (result.truncated) {
+    parts.push(t('preview_api_truncated') || 'truncated at the token limit');
+  }
+  els.apiResultMeta.textContent = parts.filter(Boolean).join(' · ');
+  setStatus(t('preview_api_status_done') || 'API response received.');
+}
+
+async function copyApiResponse() {
+  const text = els.apiResponseText?.textContent || '';
+  if (!text) return;
+  try {
+    await navigator.clipboard.writeText(text);
+    setStatus(t('preview_api_copied') || 'API response copied to clipboard.');
+  } catch (error) {
+    setStatus(`Copy failed. ${error.message || ''}`.trim());
+  }
+}
+
 function setSendInFlight(inFlight) {
   previewState.sendInFlight = inFlight;
   [els.sendBtn, els.sendBtnBottom, els.skipNextBtn].forEach(button => {
@@ -548,15 +758,18 @@ function buildCommentTreeHtml(comment, checkedIds) {
   const score = typeof comment.score === 'number' ? comment.score : 0;
   const isChecked = checkedIds.has(comment.id);
   const snippet = getSnippet(comment.text);
+  // comment.id is scraped from the page, so it is escaped like every other
+  // interpolated value even though Reddit ids are normally plain `t1_xxxxx`.
+  const commentId = escapeHtml(comment.id == null ? '' : String(comment.id));
 
-  const checkboxHtml = `<input type="checkbox" class="comment-checkbox" data-id="${comment.id}" ${isChecked ? 'checked' : ''}>`;
+  const checkboxHtml = `<input type="checkbox" class="comment-checkbox" data-id="${commentId}" ${isChecked ? 'checked' : ''}>`;
   const metaHtml = `<span class="comment-meta"><span class="author">u/${author}</span> <span class="score">(${score} pts)</span></span>`;
   const textHtml = `<span class="comment-text-snippet">${snippet}</span>`;
 
   if (hasReplies) {
     const childrenHtml = comment.replies.map(reply => buildCommentTreeHtml(reply, checkedIds)).join('');
     return `
-      <details open class="comment-node" data-comment-id="${comment.id}">
+      <details open class="comment-node" data-comment-id="${commentId}">
         <summary class="comment-summary">
           ${checkboxHtml}
           ${metaHtml}
@@ -567,7 +780,7 @@ function buildCommentTreeHtml(comment, checkedIds) {
     `;
   } else {
     return `
-      <div class="comment-leaf" data-comment-id="${comment.id}">
+      <div class="comment-leaf" data-comment-id="${commentId}">
         ${checkboxHtml}
         ${metaHtml}
         ${textHtml}

--- a/src/promptBuilder.js
+++ b/src/promptBuilder.js
@@ -210,28 +210,91 @@
     return rebuildTreeFromSelected(comments || [], selectedIds);
   }
 
+  // Rough per-comment rendering cost (author label, indentation, score, separators).
+  const COMMENT_RENDER_OVERHEAD = 40;
+  const MIN_BUDGET_COMMENTS = 10;
+
+  function estimateCommentsChars(comments) {
+    let total = 0;
+    for (const item of flattenComments(comments || [])) {
+      const comment = item.comment;
+      total += String(comment.text || '').length
+        + String(comment.author || '').length
+        + COMMENT_RENDER_OVERHEAD;
+    }
+    return total;
+  }
+
+  function estimateDataCommentsChars(data) {
+    if (Array.isArray(data?.threads)) {
+      return data.threads.reduce((sum, thread) => sum + estimateCommentsChars(thread.comments), 0);
+    }
+    return estimateCommentsChars(data?.comments);
+  }
+
+  function applyCommentLimit(data, limit, strategy) {
+    if (Array.isArray(data.threads)) {
+      const perThread = Math.max(1, Math.ceil(limit / data.threads.length));
+      return {
+        ...data,
+        threads: data.threads.map(thread => ({
+          ...thread,
+          comments: trimComments(thread.comments, perThread, strategy)
+        }))
+      };
+    }
+    return { ...data, comments: trimComments(data.comments, limit, strategy) };
+  }
+
+  // Trims comments until the rendered prompt fits `maxChars`.
+  // The tree is cloned once and sizes are estimated from summed comment text lengths
+  // (calibrated against a single full render), so a binary search costs no extra renders.
   function trimCommentsToCharBudget(data, template, options, maxChars) {
     if (!maxChars || maxChars <= 0) return data;
-    let workingData = deepClone(data);
-    let prompt = buildPromptText(workingData, template, { ...options, skipBudgetTrim: true });
-    if (prompt.length <= maxChars) return workingData;
+    const strategy = options?.trimStrategy || 'top';
+    const renderOptions = { ...options, skipBudgetTrim: true, skipContextPreset: true };
+    const render = candidate => buildPromptText(candidate, template, renderOptions);
 
-    let limit = Math.max(20, countDataComments(workingData));
-    while (prompt.length > maxChars && limit > 10) {
-      limit = Math.max(10, Math.floor(limit * 0.75));
-      if (Array.isArray(workingData.threads)) {
-        workingData.threads = workingData.threads.map(thread => ({
-          ...thread,
-          comments: trimComments(thread.comments, Math.ceil(limit / workingData.threads.length), options.trimStrategy || 'top')
-        }));
-      } else {
-        workingData.comments = trimComments(workingData.comments, limit, options.trimStrategy || 'top');
-      }
-      prompt = buildPromptText(workingData, template, { ...options, skipBudgetTrim: true });
+    const workingData = deepClone(data);
+    const fullPrompt = render(workingData);
+    if (fullPrompt.length <= maxChars) return workingData;
+
+    const totalComments = countDataComments(workingData);
+    if (totalComments <= MIN_BUDGET_COMMENTS) {
+      workingData.contextTrimmed = true;
+      return workingData;
     }
 
-    workingData.contextTrimmed = true;
-    return workingData;
+    // Calibrate: everything in the prompt that is not comment text.
+    const baseChars = Math.max(0, fullPrompt.length - estimateDataCommentsChars(workingData));
+
+    let low = MIN_BUDGET_COMMENTS;
+    let high = totalComments;
+    let best = null;
+    while (low <= high) {
+      const mid = Math.floor((low + high) / 2);
+      const candidate = applyCommentLimit(workingData, mid, strategy);
+      const estimate = baseChars + estimateDataCommentsChars(candidate);
+      if (estimate <= maxChars) {
+        best = candidate;
+        low = mid + 1;
+      } else {
+        high = mid - 1;
+      }
+    }
+
+    let result = best || applyCommentLimit(workingData, MIN_BUDGET_COMMENTS, strategy);
+
+    // The estimate can overshoot slightly; shrink with real renders as a safety net.
+    let limit = countDataComments(result);
+    for (let attempt = 0; attempt < 4 && limit > MIN_BUDGET_COMMENTS; attempt++) {
+      if (render(result).length <= maxChars) break;
+      limit = Math.max(MIN_BUDGET_COMMENTS, Math.floor(limit * 0.85));
+      result = applyCommentLimit(workingData, limit, strategy);
+    }
+
+    result.contextTrimmed = true;
+    return result;
   }
 
   function applyContextPreset(data, presetKey = 'balanced', options = {}) {
@@ -387,9 +450,15 @@
   }
 
   function buildPromptText(data, template, options = {}) {
-    const sourceData = options.contextPreset && !options.skipContextPreset
+    let sourceData = options.contextPreset && !options.skipContextPreset
       ? applyContextPreset(data, options.contextPreset, options)
       : deepClone(data);
+    if (!options.skipBudgetTrim) {
+      const maxChars = CONTEXT_PRESETS[options.contextPreset]?.maxChars || 0;
+      if (maxChars > 0) {
+        sourceData = trimCommentsToCharBudget(sourceData, template, options, maxChars);
+      }
+    }
     const content = buildContent(sourceData, options);
     const effectiveTemplate = template || 'Please analyze the following Reddit thread.\n\n{content}';
     const prompt = effectiveTemplate.includes('{content}')

--- a/src/redditParser.js
+++ b/src/redditParser.js
@@ -1,0 +1,305 @@
+// Reddit to AI - shared Reddit JSON parsing helpers.
+//
+// The content script (redditScraper.js) and the service worker used to carry two
+// separate, slowly diverging copies of this logic. Both now call into here so a
+// thread parsed on a Reddit tab and the same thread parsed in the background
+// produce identical comment objects.
+//
+// Loaded as a classic script: `importScripts('redditParser.js')` in the service
+// worker, `chrome.scripting.executeScript` on Reddit tabs, and a plain <script>
+// tag on extension pages. Mirrors promptBuilder.js's global-attach pattern.
+(function attachRedditParser(global) {
+  // Bots whose comments carry no discussion value. Matched exactly (case
+  // insensitive); the generic suffix rule below covers the long tail.
+  const KNOWN_BOTS = [
+    'AutoModerator', 'RemindMeBot', 'RepostSleuthBot', 'sneakpeekbot',
+    'TotesMessenger', 'WikiTextBot', 'B0tRank', 'CommonMisspellingBot',
+    'HelperBot_', 'WikiSummarizerBot', 'stabbot', 'SaveVideo', 'SaveThisVideo',
+    'Vredditdownloader', 'gifendore', 'haikusbot', 'nice-scores', 'userleansbot'
+  ];
+
+  const KNOWN_BOTS_LOWER = new Set(KNOWN_BOTS.map(name => name.toLowerCase()));
+
+  // A bare `endsWith('bot')` test flags real usernames such as Talbot, Abbot and
+  // Marbot, so only a `bot` suffix that is its own word (foo_bot, foo-bot) counts.
+  const BOT_SUFFIX_PATTERN = /(^|[_-])bot$/i;
+
+  function isBotAuthor(author) {
+    const name = String(author || '').trim();
+    if (!name) return false;
+    if (KNOWN_BOTS_LOWER.has(name.toLowerCase())) return true;
+    return BOT_SUFFIX_PATTERN.test(name);
+  }
+
+  const SORT_MODES = new Set(['confidence', 'top', 'new', 'controversial', 'old', 'random', 'qa', 'live']);
+
+  function normalizeSortMode(value) {
+    const sort = String(value || 'confidence').toLowerCase();
+    if (sort === 'best') return 'confidence';
+    return SORT_MODES.has(sort) ? sort : 'confidence';
+  }
+
+  function clampDepth(depth) {
+    return Math.min(Math.max(Number(depth) || 1, 1), 10);
+  }
+
+  // Builds the `.json` listing URL for a thread permalink.
+  function buildRedditJsonUrl(inputUrl, sortMode, depth) {
+    const url = new URL(inputUrl);
+    url.pathname = url.pathname.replace(/\/$/, '') + '.json';
+    url.searchParams.set('limit', '500');
+    url.searchParams.set('depth', String(clampDepth(depth)));
+    url.searchParams.set('raw_json', '1');
+    url.searchParams.set('showmore', 'true');
+    url.searchParams.set('sort', normalizeSortMode(sortMode));
+    return url.toString();
+  }
+
+  // Superset of the fields both call sites used to produce independently.
+  function parseCommentData(data, includeHidden, replies = []) {
+    if (!data) return null;
+    const isRemoved = data.body === '[removed]' || data.body === '[deleted]';
+    if (!includeHidden && isRemoved) return null;
+
+    return {
+      id: data.name,
+      parentId: data.parent_id,
+      author: data.author,
+      text: data.body || '',
+      depth: data.depth || 0,
+      score: data.score,
+      ups: data.ups,
+      downs: data.downs,
+      controversiality: data.controversiality || 0,
+      timestamp: data.created_utc ? data.created_utc * 1000 : null,
+      createdUtc: data.created_utc || null,
+      isSubmitter: data.is_submitter || false,
+      authorFlair: data.author_flair_text || null,
+      authorFlairCss: data.author_flair_css_class || null,
+      distinguished: data.distinguished || null,
+      awardCount: data.total_awards_received || 0,
+      permalink: data.permalink ? `https://www.reddit.com${data.permalink}` : null,
+      replies
+    };
+  }
+
+  // A removed/deleted comment that still has surviving replies is kept as a stub
+  // so the reply chain does not lose its parent. The two call sites label the stub
+  // differently and downstream code (history, exports) keys off those labels, so
+  // the style stays a caller choice.
+  function createOmittedParentPlaceholder(data, replies, style = 'background') {
+    const base = {
+      id: data.name || `omitted-${Math.random().toString(36).slice(2, 8)}`,
+      parentId: data.parent_id,
+      depth: data.depth || 0,
+      score: data.score || 0,
+      ups: data.ups || 0,
+      downs: data.downs || 0,
+      controversiality: data.controversiality || 0,
+      timestamp: data.created_utc ? data.created_utc * 1000 : null,
+      createdUtc: data.created_utc || null,
+      isSubmitter: false,
+      authorFlair: null,
+      authorFlairCss: null,
+      distinguished: null,
+      awardCount: data.total_awards_received || 0,
+      permalink: data.permalink ? `https://www.reddit.com${data.permalink}` : null,
+      replies
+    };
+    if (style === 'content') {
+      return {
+        ...base,
+        author: '[removed]',
+        text: '[removed parent omitted; replies preserved]',
+        omittedParent: true
+      };
+    }
+    return {
+      ...base,
+      author: '[omitted]',
+      text: '[removed/deleted parent omitted]',
+      isOmittedParent: true
+    };
+  }
+
+  function isOmittedPlaceholder(comment) {
+    return Boolean(comment && (comment.isOmittedParent || comment.omittedParent));
+  }
+
+  function parseCommentNode(child, options, depth = 0) {
+    const { includeHidden = false, maxDepth = 10, moreIds = [], placeholderStyle = 'background' } = options || {};
+    if (!child) return null;
+    if (child.kind === 'more' && Array.isArray(child.data?.children)) {
+      moreIds.push(...child.data.children);
+      return null;
+    }
+    if (child.kind !== 't1') return null;
+
+    const replies = [];
+    const replyChildren = child.data?.replies?.data?.children;
+    if (replyChildren) {
+      if (depth < maxDepth - 1) {
+        for (const reply of replyChildren) {
+          const parsed = parseCommentNode(reply, options, depth + 1);
+          if (parsed) replies.push(parsed);
+        }
+      } else {
+        // At the depth cap the replies are dropped, but their continuation tokens
+        // are still worth collecting so morechildren can fetch them later.
+        for (const reply of replyChildren) {
+          if (reply?.kind === 'more' && Array.isArray(reply.data?.children)) {
+            moreIds.push(...reply.data.children);
+          }
+        }
+      }
+    }
+
+    const comment = parseCommentData(child.data, includeHidden, replies);
+    if (!comment) {
+      return replies.length > 0 ? createOmittedParentPlaceholder(child.data, replies, placeholderStyle) : null;
+    }
+    return comment;
+  }
+
+  // Returns { roots, count } so callers that track a pre-filter total can use it.
+  function parseComments(children, options) {
+    const roots = [];
+    let count = 0;
+    for (const child of children || []) {
+      const node = parseCommentNode(child, options, 0);
+      if (node) {
+        roots.push(node);
+        count += 1 + countComments(node.replies);
+      }
+    }
+    return { roots, count };
+  }
+
+  function countComments(comments) {
+    if (!Array.isArray(comments)) return 0;
+    let total = 0;
+    const stack = [...comments];
+    while (stack.length > 0) {
+      const next = stack.pop();
+      if (!next) continue;
+      total += 1;
+      if (Array.isArray(next.replies)) stack.push(...next.replies);
+    }
+    return total;
+  }
+
+  function buildCommentMap(roots) {
+    const map = {};
+    const traverse = comments => {
+      for (const comment of comments || []) {
+        if (comment?.id) map[comment.id] = comment;
+        traverse(comment?.replies || []);
+      }
+    };
+    traverse(roots);
+    return map;
+  }
+
+  function indexCommentTree(comment, map) {
+    if (!comment?.id) return;
+    map[comment.id] = comment;
+    for (const reply of comment.replies || []) {
+      indexCommentTree(reply, map);
+    }
+  }
+
+  // morechildren responses arrive unordered, so a child can show up before its
+  // parent. Anything parked at the root is pulled back under a parent that
+  // arrives later.
+  function reparentRootChildren(parent, roots, rootIds, commentMap) {
+    if (!parent?.id) return;
+    for (let i = roots.length - 1; i >= 0; i--) {
+      const candidate = roots[i];
+      if (!candidate || candidate.id === parent.id || candidate.parentId !== parent.id) continue;
+      roots.splice(i, 1);
+      rootIds.delete(candidate.id);
+      if (!parent.replies.some(reply => reply.id === candidate.id)) {
+        parent.replies.unshift(candidate);
+      }
+    }
+    rootIds.delete(parent.id);
+    indexCommentTree(parent, commentMap);
+  }
+
+  function mergeAdditionalComments(roots, additionalComments, threadId, options = {}) {
+    const { shouldStop } = options;
+    const commentMap = buildCommentMap(roots);
+    const rootIds = new Set((roots || []).map(comment => comment?.id).filter(Boolean));
+    let addedCount = 0;
+
+    for (const comment of additionalComments || []) {
+      if (typeof shouldStop === 'function' && shouldStop()) break;
+      if (!comment || commentMap[comment.id]) continue;
+      comment.replies = Array.isArray(comment.replies) ? comment.replies : [];
+
+      if (commentMap[comment.parentId]) {
+        commentMap[comment.parentId].replies.push(comment);
+      } else {
+        // Either a genuine top-level comment (parentId === threadId) or an orphan
+        // whose parent has not arrived yet; both park at the root for now.
+        roots.push(comment);
+        rootIds.add(comment.id);
+      }
+
+      commentMap[comment.id] = comment;
+      indexCommentTree(comment, commentMap);
+      reparentRootChildren(comment, roots, rootIds, commentMap);
+      addedCount += 1;
+    }
+
+    return { roots, addedCount, threadId };
+  }
+
+  function shouldIncludeComment(comment, criteria = {}) {
+    if (isOmittedPlaceholder(comment)) return true;
+
+    const minScore = Number(criteria.minScore || 0);
+    if (minScore > 0 && (comment.score || 0) < minScore) return false;
+
+    if (criteria.hideBots && isBotAuthor(comment.author)) return false;
+
+    const authorTypes = Array.isArray(criteria.authorTypes) ? criteria.authorTypes : [];
+    if (authorTypes.length > 0) {
+      const matchesOp = authorTypes.includes('op') && comment.isSubmitter;
+      const matchesFlaired = authorTypes.includes('flaired') && comment.authorFlair;
+      if (!matchesOp && !matchesFlaired) return false;
+    }
+
+    return true;
+  }
+
+  // Excluded comments are replaced by their surviving replies rather than taking
+  // the whole subtree with them.
+  function filterComments(comments, criteria = {}) {
+    return (comments || []).flatMap(node => {
+      if (!node) return [];
+      const replies = filterComments(node.replies || [], criteria);
+      if (isOmittedPlaceholder(node) && replies.length === 0) return [];
+      if (!shouldIncludeComment(node, criteria)) return replies;
+      return [{ ...node, replies }];
+    });
+  }
+
+  global.R2AIRedditParser = {
+    KNOWN_BOTS,
+    isBotAuthor,
+    normalizeSortMode,
+    buildRedditJsonUrl,
+    parseCommentData,
+    parseCommentNode,
+    parseComments,
+    createOmittedParentPlaceholder,
+    countComments,
+    buildCommentMap,
+    indexCommentTree,
+    reparentRootChildren,
+    mergeAdditionalComments,
+    shouldIncludeComment,
+    filterComments
+  };
+})(typeof globalThis !== 'undefined' ? globalThis : window);

--- a/src/redditScraper.js
+++ b/src/redditScraper.js
@@ -22,12 +22,9 @@ if (window.__redditToAiScraperInitialized) {
     redditSortMode: 'confidence'
   };
 
-  const KNOWN_BOTS = [
-    'AutoModerator', 'RemindMeBot', 'RepostSleuthBot', 'sneakpeekbot',
-    'TotesMessenger', 'WikiTextBot', 'B0tRank', 'CommonMisspellingBot',
-    'HelperBot_', 'WikiSummarizerBot', 'stabbot', 'SaveVideo', 'SaveThisVideo',
-    'Vredditdownloader', 'gifendore', 'haikusbot', 'nice-scores', 'userleansbot'
-  ];
+  // Shared with the service worker so a tab scrape and a background scrape agree
+  // on comment shape, bot detection, merging and filtering.
+  const Parser = globalThis.R2AIRedditParser;
 
   const RATE_LIMIT = {
     minDelay: 1000,
@@ -38,16 +35,25 @@ if (window.__redditToAiScraperInitialized) {
 
   chrome.runtime.onMessage.addListener((request, _sender, sendResponse) => {
     if (request.action === 'scrapeReddit') {
+      // A full scrape can take minutes. Holding this response channel open for that
+      // long is fragile in MV3 (the service worker is torn down while it waits), so
+      // the request is only acknowledged here and the result is delivered later as
+      // its own `scrapeComplete` message, correlated by scrapeId.
+      const scrapeId = request.scrapeId || null;
       loadScrapeSettings(request).then(settings => {
         applySettings(settings, request);
-        startScrape(settings.includeHidden)
-          .then(data => sendResponse({ data }))
+        return startScrape(settings.includeHidden)
+          .then(data => reportScrapeComplete(scrapeId, { data }))
           .catch(error => {
             console.error('Reddit to AI scrape error:', error);
-            sendResponse({ error: error.message || String(error) });
+            return reportScrapeComplete(scrapeId, { error: error.message || String(error) });
           });
+      }).catch(error => {
+        console.error('Reddit to AI scrape setup error:', error);
+        reportScrapeComplete(scrapeId, { error: error.message || String(error) });
       });
-      return true;
+      sendResponse({ started: true, scrapeId });
+      return false;
     }
 
     if (request.action === 'resumeMoreChildren') {
@@ -130,15 +136,13 @@ if (window.__redditToAiScraperInitialized) {
     SCRAPER_STATE.collectedMoreIds = new Set();
     SCRAPER_STATE.failedMoreIds = [];
 
-    sendProgress(chrome.i18n.getMessage('scraper_fetching') || 'Fetching thread...', 5);
+    sendProgress(chrome.i18n.getMessage('scraper_fetching') || 'Fetching thread...', 5, 'fetch');
 
-    const url = new URL(window.location.href);
-    url.pathname = url.pathname.replace(/\/$/, '') + '.json';
-    url.searchParams.set('limit', '500');
-    url.searchParams.set('depth', String(Math.min(Math.max(SCRAPER_STATE.maxDepth, 1), 10)));
-    url.searchParams.set('raw_json', '1');
-    url.searchParams.set('showmore', 'true');
-    url.searchParams.set('sort', SCRAPER_STATE.redditSortMode);
+    const jsonUrl = Parser.buildRedditJsonUrl(
+      window.location.href,
+      SCRAPER_STATE.redditSortMode,
+      SCRAPER_STATE.maxDepth
+    );
 
     let post;
     let roots;
@@ -146,7 +150,7 @@ if (window.__redditToAiScraperInitialized) {
     let fallbackToDom = false;
 
     try {
-      const response = await fetchWithRetry(url.toString());
+      const response = await fetchWithRetry(jsonUrl);
       if (!Array.isArray(response) || response.length < 2) {
         throw new Error('Invalid Reddit JSON format.');
       }
@@ -162,7 +166,7 @@ if (window.__redditToAiScraperInitialized) {
 
       post = extractPostDetails(postData);
 
-      sendProgress(chrome.i18n.getMessage('scraper_parsing') || 'Parsing initial comments...', 15);
+      sendProgress(chrome.i18n.getMessage('scraper_parsing') || 'Parsing initial comments...', 15, 'parse');
 
       const moreIds = [];
       const parsedRes = parseComments(commentsData, includeHidden, SCRAPER_STATE.maxDepth, moreIds);
@@ -171,7 +175,7 @@ if (window.__redditToAiScraperInitialized) {
       console.log(`Reddit to AI: Initial parse - ${count} comments, ${moreIds.length} more IDs`);
 
       if (moreIds.length > 0 && !SCRAPER_STATE.stopRequested) {
-        sendProgress(chrome.i18n.getMessage('scraper_found_more', [count.toString(), moreIds.length.toString()]) || `Found ${count} comments, loading ${moreIds.length} more...`, 20);
+        sendProgress(chrome.i18n.getMessage('scraper_found_more', [count.toString(), moreIds.length.toString()]) || `Found ${count} comments, loading ${moreIds.length} more...`, 20, 'expand', { count });
         const moreResult = await fetchAllMoreComments(moreIds, includeHidden, false);
         const integration = integrateAdditionalComments(roots, moreResult.comments);
         roots = integration.roots;
@@ -185,7 +189,7 @@ if (window.__redditToAiScraperInitialized) {
     }
 
     if (fallbackToDom) {
-      sendProgress(chrome.i18n.getMessage('scraper_dom_fallback') || 'API failed. Parsing visible DOM...', 15);
+      sendProgress(chrome.i18n.getMessage('scraper_dom_fallback') || 'API failed. Parsing visible DOM...', 15, 'parse');
       const domResult = scrapeFromDOM(includeHidden);
       post = domResult.post;
       roots = domResult.comments;
@@ -195,11 +199,11 @@ if (window.__redditToAiScraperInitialized) {
       SCRAPER_STATE.subreddit = post.subreddit;
     }
 
-    sendProgress(chrome.i18n.getMessage('scraper_applying_filters') || 'Applying filters...', 95);
+    sendProgress(chrome.i18n.getMessage('scraper_applying_filters') || 'Applying filters...', 95, 'filter');
     const filteredRoots = applyFilters(roots);
     const filteredCount = countNestedReplies(filteredRoots);
 
-    sendProgress(chrome.i18n.getMessage('scraper_complete', [filteredCount.toString()]) || `Complete! ${filteredCount} comments after filtering.`, 100);
+    sendProgress(chrome.i18n.getMessage('scraper_complete', [filteredCount.toString()]) || `Complete! ${filteredCount} comments after filtering.`, 100, 'filter');
 
     return {
       post,
@@ -401,7 +405,7 @@ if (window.__redditToAiScraperInitialized) {
 
       if (!isResume) {
         const progress = 20 + Math.min(70, Math.floor((processedBatches / Math.max(initialBatchCount, processedBatches)) * 70));
-        sendProgress(chrome.i18n.getMessage('scraper_loading_batch', [processedBatches.toString(), Math.max(initialBatchCount, processedBatches).toString()]) || `Loading comments batch ${processedBatches}...`, progress);
+        sendProgress(chrome.i18n.getMessage('scraper_loading_batch', [processedBatches.toString(), Math.max(initialBatchCount, processedBatches).toString()]) || `Loading comments batch ${processedBatches}...`, progress, 'load', { current: processedBatches, total: Math.max(initialBatchCount, processedBatches) });
       }
 
       try {
@@ -485,57 +489,21 @@ if (window.__redditToAiScraperInitialized) {
   }
 
   function integrateAdditionalComments(roots, additionalComments) {
-    const commentMap = buildCommentMap(roots);
-    let addedCount = 0;
-
-    for (const comment of additionalComments) {
-      if (SCRAPER_STATE.stopRequested) break;
-      if (commentMap[comment.id]) continue;
-
-      const parentId = comment.parentId;
-      if (commentMap[parentId]) {
-        commentMap[parentId].replies.push(comment);
-      } else if (parentId === SCRAPER_STATE.threadId) {
-        roots.push(comment);
-      } else {
-        roots.push(comment);
-      }
-      commentMap[comment.id] = comment;
-      addedCount += 1;
-    }
-
-    return { roots, addedCount };
+    return Parser.mergeAdditionalComments(roots, additionalComments, SCRAPER_STATE.threadId, {
+      shouldStop: () => SCRAPER_STATE.stopRequested
+    });
   }
 
   function parseCommentData(data, includeHidden) {
-    if (!data) return null;
-    const isRemoved = data.body === '[removed]' || data.body === '[deleted]';
-    if (!includeHidden && isRemoved) return null;
-
-    return {
-      id: data.name,
-      parentId: data.parent_id,
-      author: data.author,
-      text: data.body || '',
-      depth: data.depth || 0,
-      score: data.score,
-      ups: data.ups,
-      downs: data.downs,
-      controversiality: data.controversiality || 0,
-      timestamp: data.created_utc ? data.created_utc * 1000 : null,
-      createdUtc: data.created_utc || null,
-      isSubmitter: data.is_submitter || false,
-      authorFlair: data.author_flair_text || null,
-      authorFlairCss: data.author_flair_css_class || null,
-      distinguished: data.distinguished || null,
-      awardCount: data.total_awards_received || 0,
-      permalink: data.permalink ? `https://www.reddit.com${data.permalink}` : null,
-      replies: []
-    };
+    return Parser.parseCommentData(data, includeHidden);
   }
 
   function applyFilters(roots) {
-    let result = filterTree(roots || []);
+    let result = Parser.filterComments(roots || [], {
+      minScore: SCRAPER_STATE.filterMinScore,
+      hideBots: SCRAPER_STATE.filterHideBots,
+      authorTypes: SCRAPER_STATE.filterAuthorTypes || []
+    });
 
     const topN = Number(SCRAPER_STATE.filterTopN || 0);
     if (topN > 0) {
@@ -543,41 +511,6 @@ if (window.__redditToAiScraperInitialized) {
     }
 
     return result;
-  }
-
-  function shouldInclude(comment) {
-    if (SCRAPER_STATE.filterMinScore > 0 && (comment.score || 0) < SCRAPER_STATE.filterMinScore) {
-      return false;
-    }
-
-    if (SCRAPER_STATE.filterHideBots && KNOWN_BOTS.some(bot =>
-      comment.author?.toLowerCase() === bot.toLowerCase() ||
-      comment.author?.toLowerCase().endsWith('bot')
-    )) {
-      return false;
-    }
-
-    const authorTypes = SCRAPER_STATE.filterAuthorTypes || [];
-    if (authorTypes.length > 0) {
-      const matchesOp = authorTypes.includes('op') && comment.isSubmitter;
-      const matchesFlaired = authorTypes.includes('flaired') && comment.authorFlair;
-      if (!matchesOp && !matchesFlaired) return false;
-    }
-
-    return true;
-  }
-
-  function filterTree(comments) {
-    const filtered = [];
-    for (const comment of comments) {
-      const filteredComment = { ...comment, replies: filterTree(comment.replies || []) };
-      if (shouldInclude(comment)) {
-        filtered.push(filteredComment);
-      } else if (filteredComment.replies.length > 0) {
-        filtered.push(...filteredComment.replies);
-      }
-    }
-    return filtered;
   }
 
   function limitCommentsByStrategy(comments, limit, strategy) {
@@ -603,18 +536,6 @@ if (window.__redditToAiScraperInitialized) {
       return topIds.has(node.id) || replies.length > 0 ? [{ ...node, replies }] : [];
     });
     return prune(comments);
-  }
-
-  function buildCommentMap(roots) {
-    const map = {};
-    const traverse = comments => {
-      for (const comment of comments || []) {
-        map[comment.id] = comment;
-        traverse(comment.replies || []);
-      }
-    };
-    traverse(roots);
-    return map;
   }
 
   function extractPostDetails(data) {
@@ -742,87 +663,20 @@ if (window.__redditToAiScraperInitialized) {
   }
 
   function parseComments(children, includeHidden, maxDepth, moreIds) {
-    const roots = [];
-    let count = 0;
-
-    for (const child of children || []) {
-      if (child.kind === 'more' && Array.isArray(child.data?.children)) {
-        moreIds.push(...child.data.children);
-        continue;
-      }
-
-      const node = parseCommentNode(child, includeHidden, 0, maxDepth, moreIds);
-      if (node) {
-        roots.push(node);
-        count += 1 + countNestedReplies(node.replies);
-      }
-    }
-
-    return { roots, count };
-  }
-
-  function parseCommentNode(child, includeHidden, currentDepth, maxDepth, moreIds) {
-    if (child.kind === 'more' && Array.isArray(child.data?.children)) {
-      moreIds.push(...child.data.children);
-      return null;
-    }
-    if (child.kind !== 't1') return null;
-
-    let comment = parseCommentData(child.data, includeHidden);
-    if (!comment && child.data?.replies?.data?.children) {
-      comment = {
-        id: child.data.name || `omitted-${Math.random().toString(36).slice(2, 8)}`,
-        parentId: child.data.parent_id,
-        author: '[removed]',
-        text: '[removed parent omitted; replies preserved]',
-        depth: child.data.depth || currentDepth,
-        score: child.data.score || 0,
-        ups: child.data.ups || 0,
-        downs: child.data.downs || 0,
-        controversiality: child.data.controversiality || 0,
-        timestamp: child.data.created_utc ? child.data.created_utc * 1000 : null,
-        createdUtc: child.data.created_utc || null,
-        isSubmitter: Boolean(child.data.is_submitter),
-        authorFlair: child.data.author_flair_text || null,
-        distinguished: child.data.distinguished || null,
-        awardCount: child.data.total_awards_received || 0,
-        permalink: child.data.permalink ? `https://www.reddit.com${child.data.permalink}` : null,
-        replies: [],
-        omittedParent: true
-      };
-    }
-    if (!comment) return null;
-
-    if (currentDepth < maxDepth - 1 && child.data?.replies?.data?.children) {
-      for (const replyChild of child.data.replies.data.children) {
-        const replyNode = parseCommentNode(replyChild, includeHidden, currentDepth + 1, maxDepth, moreIds);
-        if (replyNode) comment.replies.push(replyNode);
-      }
-    } else if (child.data?.replies?.data?.children) {
-      for (const replyChild of child.data.replies.data.children) {
-        if (replyChild.kind === 'more' && Array.isArray(replyChild.data?.children)) {
-          moreIds.push(...replyChild.data.children);
-        }
-      }
-    }
-
-    return comment;
+    return Parser.parseComments(children, {
+      includeHidden,
+      maxDepth,
+      moreIds,
+      placeholderStyle: 'content'
+    });
   }
 
   function countNestedReplies(replies) {
-    let count = 0;
-    for (const reply of replies || []) {
-      count += 1;
-      count += countNestedReplies(reply.replies || []);
-    }
-    return count;
+    return Parser.countComments(replies);
   }
 
   function normalizeSortMode(value) {
-    const sort = String(value || 'confidence').toLowerCase();
-    if (sort === 'best') return 'confidence';
-    const allowed = new Set(['confidence', 'top', 'new', 'controversial', 'old', 'random', 'qa', 'live']);
-    return allowed.has(sort) ? sort : 'confidence';
+    return Parser.normalizeSortMode(value);
   }
 
   function decodeRedditUrl(url) {
@@ -847,16 +701,33 @@ if (window.__redditToAiScraperInitialized) {
   }
 
   function isRedditHostedUrl(url) {
-    return /(?:reddit\.com|redd\.it|redd\.itt|i\.redd\.it|preview\.redd\.it|v\.redd\.it)/i.test(url || '');
+    return /(?:reddit\.com|redd\.it|i\.redd\.it|preview\.redd\.it|v\.redd\.it)/i.test(url || '');
   }
 
   function delay(ms) {
     return new Promise(resolve => setTimeout(resolve, ms));
   }
 
-  function sendProgress(message, percentage) {
+  // Delivers the finished scrape (or its failure) on a fresh message. Sending this
+  // also wakes the service worker if it was torn down while the scrape ran.
+  function reportScrapeComplete(scrapeId, payload) {
     try {
-      chrome.runtime.sendMessage({ action: 'progressUpdate', message, percentage });
+      chrome.runtime.sendMessage({ action: 'scrapeComplete', scrapeId, ...payload }, () => {
+        if (chrome.runtime.lastError) {
+          console.warn('Reddit to AI: scrapeComplete delivery failed:', chrome.runtime.lastError.message);
+        }
+      });
+    } catch (error) {
+      console.error('Reddit to AI: could not deliver scrapeComplete:', error);
+    }
+  }
+
+  // `phase` (and `batch`, where a counter exists) travel alongside the human-readable
+  // message so the panel and popup never have to parse localized text to know where
+  // the scrape is. See DEFAULT_STATE in service_worker.js for the phase vocabulary.
+  function sendProgress(message, percentage, phase, batch) {
+    try {
+      chrome.runtime.sendMessage({ action: 'progressUpdate', message, percentage, phase, batch });
     } catch (error) {
       console.debug('Progress update failed:', error);
     }

--- a/src/service_worker.js
+++ b/src/service_worker.js
@@ -1,16 +1,37 @@
 /* global importScripts */
-importScripts('cl100k_base.js', 'promptBuilder.js');
+// Chrome runs this file as an MV3 service worker, where `importScripts` pulls in the
+// shared libraries. Firefox runs it as an MV3 background event page, where
+// `importScripts` does not exist - there the same four files are listed ahead of this
+// one in `background.scripts`, so the globals are already present and the call is
+// skipped. Keep both lists in the same order (see scripts/firefox-manifest.mjs).
+if (typeof importScripts === 'function') {
+  importScripts('cl100k_base.js', 'redditParser.js', 'promptBuilder.js', 'apiProviders.js');
+}
 
 const DEFAULT_PROMPT_TEMPLATE = 'Summarize the following Reddit thread:\n\n{content}';
 const DEFAULT_HISTORY_LIMIT = 10;
 const PREVIEW_STORAGE_KEY = 'redditPreviewData';
 const PASTE_STORAGE_KEY = 'redditPendingPaste';
 const LEGACY_THREAD_KEY = 'redditThreadData';
+const SCRAPING_STATE_KEY = 'redditScrapingState';
+const SCRAPE_CONTEXT_KEY = 'redditActiveScrape';
+// API keys live in chrome.storage.local only - never in storage.sync, which would
+// replicate them through Google's servers.
+const DIRECT_API_CONFIG_KEY = 'directApiConfig';
 
+// `phase`, `status` and `batch` are the machine-readable half of the state. The UI
+// keys off them so it never has to pattern-match the localized `message` text.
+// phase: 'idle' | 'prepare' | 'fetch' | 'parse' | 'load' | 'expand' | 'media'
+//        | 'filter' | 'build' | 'complete' | 'error'
+// status: 'idle' | 'running' | 'complete' | 'error'
+// batch: null | { current, total }
 const DEFAULT_STATE = {
   isActive: false,
   message: chrome.i18n.getMessage('panel_status_ready') || 'Ready to scrape.',
   percentage: 0,
+  phase: 'idle',
+  status: 'idle',
+  batch: null,
   summary: null,
   error: null,
   lastScrapedTabId: null
@@ -22,31 +43,192 @@ const activePasteHandoffs = new Set();
 
 console.debug('Service worker initialised.');
 
-// Auto-resume from storage on wake up
-chrome.storage.local.get('activeBatch', (result) => {
-  if (result && result.activeBatch) {
-    if (scrapingState.isActive) {
-      console.debug('Skipping auto-resume: scraping is already active');
+// An MV3 service worker is torn down between events, so a scrape that outlives the
+// worker has to be reconstructed from storage.session on the next wake-up. Every
+// message is gated on `ready` so no handler can observe half-restored state, and so
+// the activeBatch auto-resume decision is made exactly once, before any message
+// (in particular a fresh `scrapeReddit`) can race it.
+//
+// Deliberately callback-chained rather than promise-chained: when the storage
+// callbacks are synchronous the whole restore completes in this same tick, which is
+// what keeps a woken worker from briefly looking idle.
+const ready = new Promise(resolve => {
+  restoreScrapingState(() => {
+    autoResumeBatch(resolve);
+  });
+});
+
+function restoreScrapingState(done) {
+  if (!chrome.storage.session) {
+    done();
+    return;
+  }
+  chrome.storage.session.get([SCRAPING_STATE_KEY, SCRAPE_CONTEXT_KEY], (result) => {
+    if (chrome.runtime.lastError) {
+      console.debug('Scraping state restore skipped:', chrome.runtime.lastError.message);
+      done();
       return;
     }
-    console.debug('Auto-resuming active batch scrape from storage...', result.activeBatch);
-    resumeBatchScrape(result.activeBatch).catch(err => {
-      console.error('Failed to auto-resume batch scrape:', err);
-    });
-  }
-});
+    const stored = result?.[SCRAPING_STATE_KEY];
+    if (stored) {
+      // A scrape only counts as still running if its handoff context survived too;
+      // otherwise the previous worker died past the point of no return and the flag
+      // would wedge the UI (and block the batch auto-resume below) forever.
+      scrapingState = { ...DEFAULT_STATE, ...stored, isActive: Boolean(result?.[SCRAPE_CONTEXT_KEY]) };
+    }
+    done();
+  });
+}
+
+function autoResumeBatch(done) {
+  chrome.storage.local.get('activeBatch', (result) => {
+    if (result && result.activeBatch && !scrapingState.isActive) {
+      console.debug('Auto-resuming active batch scrape from storage...', result.activeBatch);
+      resumeBatchScrape(result.activeBatch).catch(err => {
+        console.error('Failed to auto-resume batch scrape:', err);
+      });
+    }
+    done();
+  });
+}
 
 chrome.runtime.onInstalled.addListener(() => {
   console.debug('Reddit to AI installed.');
   syncSelectors().catch(err => console.error('Selector sync on installed failed:', err));
   registerAllCustomOrigins().catch(err => console.error('Failed to register custom origins on installed:', err));
+  registerContextMenus();
 });
+
+// =====================
+// Context menu / keyboard shortcut entry points
+// =====================
+
+const CONTEXT_MENU_PAGE_ID = 'r2ai-scrape-page';
+const CONTEXT_MENU_LINK_ID = 'r2ai-scrape-link';
+// Thread pages only: the scraper needs a /comments/ permalink, so subreddit
+// listings and profiles are deliberately excluded.
+const THREAD_URL_PATTERNS = [
+  '*://*.reddit.com/r/*/comments/*',
+  '*://*.reddit.com/comments/*',
+  '*://*.reddit.com/user/*/comments/*',
+  'https://*.redd.it/*'
+];
+
+function contextMenuTitle() {
+  return chrome.i18n.getMessage('context_menu_scrape_thread') || 'Scrape this thread with Reddit to AI';
+}
+
+function registerContextMenus() {
+  if (!chrome.contextMenus?.create) return;
+  // onInstalled also fires on update, so clear first to avoid duplicate-id errors.
+  chrome.contextMenus.removeAll(() => {
+    if (chrome.runtime.lastError) console.debug('Context menu reset skipped:', chrome.runtime.lastError.message);
+    chrome.contextMenus.create({
+      id: CONTEXT_MENU_PAGE_ID,
+      title: contextMenuTitle(),
+      contexts: ['page', 'selection'],
+      documentUrlPatterns: THREAD_URL_PATTERNS
+    }, () => chrome.runtime.lastError && console.debug('Page context menu skipped:', chrome.runtime.lastError.message));
+    chrome.contextMenus.create({
+      id: CONTEXT_MENU_LINK_ID,
+      title: contextMenuTitle(),
+      contexts: ['link'],
+      // targetUrlPatterns matches the link href, so a thread link works from any page.
+      targetUrlPatterns: THREAD_URL_PATTERNS
+    }, () => chrome.runtime.lastError && console.debug('Link context menu skipped:', chrome.runtime.lastError.message));
+  });
+}
+
+if (chrome.contextMenus?.onClicked) {
+  chrome.contextMenus.onClicked.addListener((info, tab) => {
+    ready
+      .then(() => {
+        if (info.menuItemId === CONTEXT_MENU_LINK_ID && info.linkUrl) {
+          return scrapeThreadInNewTab(info.linkUrl);
+        }
+        if (info.menuItemId === CONTEXT_MENU_PAGE_ID) {
+          return handleScrapeRequest({ tabId: tab?.id }, null);
+        }
+        return undefined;
+      })
+      .catch(error => notifyEntryPointFailure(error));
+  });
+}
+
+if (chrome.commands?.onCommand) {
+  chrome.commands.onCommand.addListener((command) => {
+    if (command !== 'scrape-current-thread') return;
+    // No tabId: handleScrapeRequest falls back to the active tab, exactly like the
+    // popup's scrape with stored settings and no per-scrape filter overrides.
+    ready
+      .then(() => handleScrapeRequest({}, null))
+      .catch(error => notifyEntryPointFailure(error));
+  });
+}
+
+function notifyEntryPointFailure(error) {
+  console.error('Reddit to AI: scrape entry point failed:', error);
+  showNotificationIfEnabled(
+    chrome.i18n.getMessage('extName') || 'Reddit to AI',
+    error?.message || (chrome.i18n.getMessage('sw_error_not_reddit') || 'Active tab is not a Reddit thread.')
+  );
+}
+
+// Opens a thread link in a background tab, waits for it to finish loading, then runs
+// the normal tab scrape against it. Batch mode cannot be reused here: it fetches the
+// Reddit JSON API instead of scraping a rendered page.
+async function scrapeThreadInNewTab(url) {
+  if (!isRedditUrl(url)) throw new Error('Active tab is not a Reddit thread.');
+  // Checked before opening the tab so a busy worker does not leave a stray tab behind.
+  if (scrapingState.isActive) throw new Error('Scraping already in progress.');
+  const tab = await chrome.tabs.create({ url, active: false });
+  await waitForTabLoad(tab.id);
+  return handleScrapeRequest({ tabId: tab.id }, null);
+}
+
+function waitForTabLoad(tabId, timeoutMs = 30000) {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const finish = (error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      chrome.tabs.onUpdated.removeListener(onUpdated);
+      if (error) reject(error);
+      else resolve();
+    };
+    const onUpdated = (updatedTabId, changeInfo) => {
+      if (updatedTabId === tabId && changeInfo.status === 'complete') finish();
+    };
+    const timer = setTimeout(() => finish(new Error('Timed out waiting for the Reddit tab to load.')), timeoutMs);
+    chrome.tabs.onUpdated.addListener(onUpdated);
+    // The tab may already have finished loading before the listener was attached.
+    chrome.tabs.get(tabId, tab => {
+      if (chrome.runtime.lastError) {
+        finish(new Error(chrome.runtime.lastError.message));
+        return;
+      }
+      if (tab?.status === 'complete') finish();
+    });
+  });
+}
 
 // =====================
 // Message Handlers
 // =====================
 
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+  // Every branch answers after `ready`, so the listener always claims the async
+  // response channel.
+  ready.then(() => handleRuntimeMessage(request, sender, sendResponse))
+    .catch(error => {
+      console.error('Message handling failed:', error);
+      sendResponse({ status: 'error', error: error.message });
+    });
+  return true;
+});
+
+function handleRuntimeMessage(request, sender, sendResponse) {
   switch (request.action) {
     case 'scrapeReddit': {
       const handler = Array.isArray(request.batchUrls) && request.batchUrls.length > 0
@@ -60,35 +242,61 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
             isActive: false,
             error: error.message,
             message: `Error: ${error.message}`,
-            percentage: -1
+            percentage: -1,
+            phase: 'error',
+            status: 'error',
+            batch: null
           });
           sendResponse({ status: 'error', error: error.message, currentState: scrapingState });
         });
-      return true;
+      return;
+    }
+    case 'scrapeComplete': {
+      // Final payload from the content script, delivered as its own message so the
+      // original request/response pair does not have to stay open for the whole
+      // scrape. May arrive at a worker that was restarted mid-scrape.
+      finishTabScrape(request.scrapeId, { data: request.data, error: request.error })
+        .then(() => sendResponse({ ok: true }))
+        .catch(error => {
+          console.error('Failed to finish scrape:', error);
+          sendResponse({ ok: false, error: error.message });
+        });
+      return;
     }
     case 'stopScraping':
-      stopActiveScrape();
-      sendResponse({ status: 'stopping', currentState: scrapingState });
-      return false;
-    case 'progressUpdate':
-      if (request.message) setScrapingState({ message: request.message });
-      if (typeof request.percentage === 'number') setScrapingState({ percentage: request.percentage });
+      stopActiveScrape()
+        .catch(error => console.warn('Reddit to AI: Stop cleanup failed:', error))
+        .then(() => sendResponse({ status: 'stopping', currentState: scrapingState }));
+      return;
+    case 'progressUpdate': {
+      const patch = {};
+      if (request.message) patch.message = request.message;
+      if (typeof request.percentage === 'number') patch.percentage = request.percentage;
+      if (request.phase) {
+        patch.phase = request.phase;
+        patch.status = 'running';
+        // `batch` is re-derived on every phase-carrying update so a stale batch
+        // counter cannot survive past the phase that produced it.
+        patch.batch = request.batch || null;
+      }
+      if (Object.keys(patch).length > 0) setScrapingState(patch);
       sendResponse({ ok: true });
-      return false;
+      return;
+    }
     case 'getScrapingState':
       sendResponse(scrapingState);
-      return false;
+      return;
     case 'notifyUser':
       if (request.title && request.message) {
         showNotificationIfEnabled(request.title, request.message, request.notificationIdBase);
       }
       sendResponse({ ok: true });
-      return false;
+      return;
     case 'fetchImage': {
       fetchImageAsBase64(request.url)
         .then(result => sendResponse(result))
         .catch(error => sendResponse({ error: error.message }));
-      return true;
+      return;
     }
     case 'getPreviewData': {
       getPreviewData()
@@ -97,41 +305,65 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
           return loadSettings().then(settings => {
             const merged = { ...settings, ...payload.settings };
             const resolved = resolveSubredditSettings(payload.data.post?.subreddit, merged);
-            return sendResponse({ data: payload.data, settings: resolved });
+            return sendResponse({ data: payload.data, settings: resolved, historyId: payload.historyId || null });
           });
         })
         .catch(error => sendResponse({ error: error.message }));
-      return true;
+      return;
     }
     case 'sendPromptToAi': {
       sendPromptToAi(request)
         .then(result => sendResponse(result))
         .catch(error => sendResponse({ error: error.message }));
-      return true;
+      return;
+    }
+    case 'sendPromptViaApi': {
+      sendPromptViaApi(request)
+        .then(result => sendResponse(result))
+        .catch(error => sendResponse({
+          error: error.message,
+          retryable: error.retryable === true
+        }));
+      return;
+    }
+    case 'getDirectApiStatus': {
+      getDirectApiStatus()
+        .then(status => sendResponse(status))
+        .catch(error => sendResponse({ error: error.message }));
+      return;
+    }
+    case 'testDirectApiKey': {
+      testDirectApiKey(request)
+        .then(result => sendResponse(result))
+        .catch(error => sendResponse({
+          error: error.message,
+          retryable: error.retryable === true
+        }));
+      return;
     }
     case 'getPendingPasteData': {
       getPendingPasteData()
         .then(payload => sendResponse({ payload }))
         .catch(error => sendResponse({ error: error.message }));
-      return true;
+      return;
     }
     case 'markPendingPasteConsumed': {
       markPendingPasteConsumed(request.pasteId)
         .then(() => sendResponse({ ok: true }))
         .catch(error => sendResponse({ error: error.message }));
-      return true;
+      return;
     }
     case 'recordPasteFailure': {
       recordPasteFailure(request)
         .then(() => sendResponse({ ok: true }))
         .catch(error => sendResponse({ error: error.message }));
-      return true;
+      return;
     }
     case 'resumeMissingComments': {
       resumeMissingComments()
         .then(result => sendResponse(result))
         .catch(error => sendResponse({ error: error.message }));
-      return true;
+      return;
     }
     case 'getQuickTokenEstimate': {
       getQuickTokenEstimate(request.tabId, request.url)
@@ -140,7 +372,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
           console.warn('Quick estimate failed:', error);
           sendResponse({ error: error.message });
         });
-      return true;
+      return;
     }
     case 'getLocaleData': {
       getLocaleData(request.lang)
@@ -149,86 +381,73 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
           console.error('Failed to read locale data:', error);
           sendResponse({ success: false, error: error.message });
         });
-      return true;
+      return;
     }
     case 'focusLastRedditTab': {
       focusLastRedditTab()
         .then(() => sendResponse({ ok: true }))
         .catch(error => sendResponse({ error: error.message }));
-      return true;
+      return;
     }
     case 'getHistory': {
       getHistory()
         .then(history => sendResponse({ history }))
         .catch(error => sendResponse({ error: error.message }));
-      return true;
+      return;
     }
     case 'deleteHistoryItem': {
       deleteFromHistory(request.historyId)
         .then(history => sendResponse({ history }))
         .catch(error => sendResponse({ error: error.message }));
-      return true;
+      return;
     }
     case 'clearHistory': {
       clearHistory()
         .then(() => sendResponse({ success: true }))
         .catch(error => sendResponse({ error: error.message }));
-      return true;
+      return;
     }
     case 'resendHistoryItem': {
       resendHistoryItem(request.historyId, request.aiProvider)
         .then(result => sendResponse(result))
         .catch(error => sendResponse({ error: error.message }));
-      return true;
+      return;
     }
     case 'getHistoryItem': {
       getHistoryItem(request.historyId)
         .then(item => sendResponse({ item }))
         .catch(error => sendResponse({ error: error.message }));
-      return true;
+      return;
     }
     case 'updateHistoryItem': {
       updateHistoryItem(request.historyId, request.patch || {})
         .then(history => sendResponse({ history }))
         .catch(error => sendResponse({ error: error.message }));
-      return true;
+      return;
     }
     case 'compareHistoryItems': {
       compareHistoryItems(request.historyIds || [])
         .then(result => sendResponse(result))
         .catch(error => sendResponse({ error: error.message }));
-      return true;
-    }
-    case 'checkLocalAiCapability': {
-      checkLocalAiCapability()
-        .then(available => sendResponse({ available }))
-        .catch(error => sendResponse({ available: false, error: error.message }));
-      return true;
-    }
-    case 'generateLocalSummary': {
-      generateLocalSummary(request.promptText)
-        .then(summary => sendResponse({ status: 'success', summary }))
-        .catch(error => sendResponse({ status: 'error', error: error.message }));
-      return true;
+      return;
     }
     case 'registerCustomOrigin': {
       registerCustomOriginScript(request.origin)
         .then(() => sendResponse({ status: 'success' }))
         .catch(error => sendResponse({ status: 'error', error: error.message }));
-      return true;
+      return;
     }
     case 'unregisterCustomOrigin': {
       unregisterCustomOriginScript(request.origin)
         .then(() => sendResponse({ status: 'success' }))
         .catch(error => sendResponse({ status: 'error', error: error.message }));
-      return true;
+      return;
     }
     default:
       console.warn('Unhandled runtime message:', request);
       sendResponse({ status: 'ignored' });
-      return false;
   }
-});
+}
 
 // Port connection handler for streaming Local AI summaries
 if (chrome.runtime.onConnect) {
@@ -245,24 +464,6 @@ if (chrome.runtime.onConnect) {
         clearInterval(intervalId);
       });
     }
-    if (port.name === 'local-ai-summary') {
-      port.onMessage.addListener(async (msg) => {
-        if (msg.action === 'summarize') {
-          try {
-            const summary = await generateLocalSummary(msg.promptText, (chunk) => {
-              try {
-                port.postMessage({ status: 'chunk', text: chunk });
-              } catch (err) {
-                console.debug('Port disconnected during streaming:', err);
-              }
-            });
-            port.postMessage({ status: 'success', text: summary });
-          } catch (error) {
-            port.postMessage({ status: 'error', error: error.message });
-          }
-        }
-      });
-    }
   });
 }
 
@@ -277,6 +478,9 @@ async function handleScrapeRequest(request, sender) {
     isActive: true,
     message: chrome.i18n.getMessage('sw_status_preparing') || 'Preparing to scrape.',
     percentage: 5,
+    phase: 'prepare',
+    status: 'running',
+    batch: null,
     summary: null,
     error: null
   });
@@ -288,12 +492,17 @@ async function handleScrapeRequest(request, sender) {
       isActive: false,
       message: chrome.i18n.getMessage('popup_status_navigate') || 'Open a Reddit thread before scraping.',
       percentage: -1,
+      phase: 'error',
+      status: 'error',
+      batch: null,
       error: chrome.i18n.getMessage('sw_error_not_reddit') || 'Active tab is not a Reddit thread.'
     });
     throw new Error('Active tab is not a Reddit thread.');
   }
 
+  const scrapeId = createId();
   currentScrape = {
+    scrapeId,
     tabId: activeTab.id,
     stopRequested: false,
     storageOption: 'persistent',
@@ -303,78 +512,133 @@ async function handleScrapeRequest(request, sender) {
   setScrapingState({ lastScrapedTabId: activeTab.id });
 
   try {
-    await injectContentScripts(activeTab.id);
-    setScrapingState({ message: chrome.i18n.getMessage('sw_status_collecting') || 'Collecting data from page.', percentage: 20 });
-
-    const scrapeResponse = await requestScrapeFromTab(activeTab.id, request.includeHidden, request.filters || {});
-    if (scrapeResponse?.error) throw new Error(`Content script error: ${scrapeResponse.error}`);
-    if (!scrapeResponse?.data) throw new Error('Content script returned no data.');
-    if (currentScrape.stopRequested) throw new Error('Scraping stopped by user.');
-
-    setScrapingState({ message: chrome.i18n.getMessage('sw_status_processing') || 'Preparing scraped data.', percentage: 65 });
-
+    // Settings are resolved up front rather than after the scrape so the whole
+    // handoff context can be persisted before the tab starts working. A worker that
+    // is restarted mid-scrape then has everything it needs to finish the pipeline.
     const settings = await loadSettings();
     const effectiveSettings = mergeRequestFiltersIntoSettings(settings, request.filters || {}, request);
     currentScrape.storageOption = effectiveSettings.dataStorageOption;
-    const refreshedTab = await getTabById(currentScrape.tabId);
-    const processedData = enrichScrapedData(scrapeResponse.data, getTabUrl(refreshedTab), {
-      redditTabId: activeTab.id,
+
+    const context = {
+      scrapeId,
+      tabId: activeTab.id,
+      settings: effectiveSettings,
+      startedAt: Date.now()
+    };
+    await setStorage(chrome.storage.session, { [SCRAPE_CONTEXT_KEY]: context });
+
+    await injectContentScripts(activeTab.id);
+    setScrapingState({ message: chrome.i18n.getMessage('sw_status_collecting') || 'Collecting data from page.', percentage: 20, phase: 'fetch', status: 'running' });
+
+    const ack = await requestScrapeFromTab(activeTab.id, request.includeHidden, request.filters || {}, scrapeId);
+    if (ack?.error) throw new Error(`Content script error: ${ack.error}`);
+
+    // A content script left over from a previous extension version still replies
+    // with the finished payload instead of acknowledging the start.
+    if (ack?.data) {
+      finishTabScrape(scrapeId, { data: ack.data }).catch(error => {
+        console.error('Legacy scrape handoff failed:', error);
+      });
+    } else if (!ack?.started) {
+      throw new Error('Content script did not acknowledge the scrape request.');
+    }
+
+    // Resolves as soon as the tab has started. The result arrives later as its own
+    // `scrapeComplete` message, so the popup follows progress through scraping
+    // state updates rather than through this response.
+    return { started: true, scrapeId, preview: effectiveSettings.showPromptPreview !== false, direct: effectiveSettings.showPromptPreview === false };
+  } catch (error) {
+    await clearScrapeContext();
+    currentScrape = null;
+    throw error;
+  }
+}
+
+async function getActiveScrapeContext(scrapeId) {
+  const stored = await getStorage(chrome.storage.session, SCRAPE_CONTEXT_KEY);
+  const context = stored?.[SCRAPE_CONTEXT_KEY] || null;
+  if (!context) return null;
+  if (scrapeId && context.scrapeId && context.scrapeId !== scrapeId) return null;
+  return context;
+}
+
+async function clearScrapeContext() {
+  await removeStorage(chrome.storage.session, [SCRAPE_CONTEXT_KEY])
+    .catch(error => console.warn('Reddit to AI: Failed to clear scrape context:', error));
+}
+
+// Second half of a single-thread scrape: everything that used to run inline once
+// `chrome.tabs.sendMessage` finally called back. Driven by the `scrapeComplete`
+// message so it also runs correctly on a worker that started after the scrape did.
+async function finishTabScrape(scrapeId, { data, error } = {}) {
+  const context = await getActiveScrapeContext(scrapeId);
+  if (!context) {
+    console.debug('Ignoring scrapeComplete for an unknown or superseded scrape:', scrapeId);
+    return { ignored: true };
+  }
+
+  const stopRequested = Boolean(currentScrape?.stopRequested);
+  try {
+    if (error) throw new Error(`Content script error: ${error}`);
+    if (!data) throw new Error('Content script returned no data.');
+    if (stopRequested) throw new Error('Scraping stopped by user.');
+
+    setScrapingState({ message: chrome.i18n.getMessage('sw_status_processing') || 'Preparing scraped data.', percentage: 65, phase: 'build', status: 'running', batch: null });
+
+    const effectiveSettings = context.settings || await loadSettings();
+    const refreshedTab = await getTabById(context.tabId).catch(() => null);
+    const processedData = enrichScrapedData(data, getTabUrl(refreshedTab), {
+      redditTabId: context.tabId,
       settings: effectiveSettings
     });
     processedData.timestamp = Date.now();
 
-    await savePreviewData(processedData, effectiveSettings);
+    let historyEntry = null;
     if (effectiveSettings.dataStorageOption === 'persistent') {
-      await addToHistory(processedData, effectiveSettings);
+      historyEntry = await addToHistory(processedData, effectiveSettings);
     }
-
-    if (request.localSummarize) {
-      setScrapingState({ message: 'Generating local summary...', percentage: 90, summary: '' });
-      const renderedData = R2AIPrompt.applyContextPreset(processedData, effectiveSettings.contextPreset || 'balanced', effectiveSettings);
-      const promptText = R2AIPrompt.buildPromptText(renderedData, effectiveSettings.defaultPromptTemplate, {
-        ...effectiveSettings,
-        contextPreset: null
-      });
-
-      const summaryText = await generateLocalSummary(promptText, (chunk) => {
-        setScrapingState({
-          isActive: true,
-          percentage: 90,
-          summary: chunk,
-          message: 'Generating local summary...'
-        });
-      });
-
-      setScrapingState({
-        isActive: false,
-        percentage: 100,
-        summary: summaryText,
-        message: 'Summary complete!',
-        error: null
-      });
-
-      return { summary: summaryText, local: true };
-    }
+    await savePreviewData(processedData, effectiveSettings, { historyId: historyEntry?.id || null });
 
     if (effectiveSettings.showPromptPreview === false) {
-      setScrapingState({ message: 'Opening AI tab...', percentage: 86 });
+      setScrapingState({ message: 'Opening AI tab...', percentage: 86, phase: 'build', status: 'running' });
       await sendDataDirectlyToAi(processedData, effectiveSettings);
     } else {
-      setScrapingState({ message: 'Opening prompt preview...', percentage: 86 });
+      setScrapingState({ message: 'Opening prompt preview...', percentage: 86, phase: 'build', status: 'running' });
       await openPreviewTab();
     }
 
     setScrapingState({
       isActive: false,
       percentage: 100,
+      phase: 'complete',
+      status: 'complete',
+      batch: null,
       summary: null,
       message: effectiveSettings.showPromptPreview === false ? 'Content sent directly to AI.' : 'Content ready for prompt preview.',
       error: null
     });
 
-    return { summary: null, preview: effectiveSettings.showPromptPreview !== false, direct: effectiveSettings.showPromptPreview === false };
+    showNotificationIfEnabled(
+      chrome.i18n.getMessage('extName') || 'Reddit to AI',
+      effectiveSettings.showPromptPreview === false ? 'Content sent directly to AI.' : 'Content ready for prompt preview.'
+    );
+
+    return { success: true };
+  } catch (finishError) {
+    console.error('Scrape failed:', finishError);
+    setScrapingState({
+      isActive: false,
+      error: finishError.message,
+      message: `Error: ${finishError.message}`,
+      percentage: -1,
+      phase: 'error',
+      status: 'error',
+      batch: null
+    });
+    throw finishError;
   } finally {
-    currentScrape = null;
+    await clearScrapeContext();
+    if (currentScrape?.scrapeId === context.scrapeId) currentScrape = null;
   }
 }
 
@@ -399,6 +663,9 @@ async function resumeBatchScrape(batch) {
       ? `Resuming scraping of ${urls.length} threads (${initialIndex}/${urls.length}).`
       : `Preparing to scrape ${urls.length} threads.`,
     percentage: 5 + Math.floor((initialIndex / urls.length) * 85),
+    phase: 'prepare',
+    status: 'running',
+    batch: { current: initialIndex, total: urls.length },
     summary: null,
     error: null
   });
@@ -416,7 +683,13 @@ async function resumeBatchScrape(batch) {
         throw new Error('Batch scraping stopped by user.');
       }
       const percentage = 10 + Math.floor((i / urls.length) * 70);
-      setScrapingState({ message: `Scraping thread ${i + 1}/${urls.length}...`, percentage });
+      setScrapingState({
+        message: `Scraping thread ${i + 1}/${urls.length}...`,
+        percentage,
+        phase: 'load',
+        status: 'running',
+        batch: { current: i + 1, total: urls.length }
+      });
       const thread = await scrapeThreadFromUrl(urls[i], effectiveSettings, batchFilters);
       threads.push(thread);
 
@@ -458,21 +731,25 @@ async function resumeBatchScrape(batch) {
       timestamp: Date.now()
     };
 
-    await savePreviewData(batchData, effectiveSettings);
+    let batchHistoryEntry = null;
     if (effectiveSettings.dataStorageOption === 'persistent') {
-      await addToHistory(batchData, effectiveSettings);
+      batchHistoryEntry = await addToHistory(batchData, effectiveSettings);
     }
+    await savePreviewData(batchData, effectiveSettings, { historyId: batchHistoryEntry?.id || null });
 
     if (effectiveSettings.showPromptPreview === false) {
-      setScrapingState({ message: 'Opening AI tab...', percentage: 90 });
+      setScrapingState({ message: 'Opening AI tab...', percentage: 90, phase: 'build', status: 'running', batch: null });
       await sendDataDirectlyToAi(batchData, effectiveSettings);
     } else {
-      setScrapingState({ message: 'Opening prompt preview...', percentage: 90 });
+      setScrapingState({ message: 'Opening prompt preview...', percentage: 90, phase: 'build', status: 'running', batch: null });
       await openPreviewTab();
     }
     setScrapingState({
       isActive: false,
       percentage: 100,
+      phase: 'complete',
+      status: 'complete',
+      batch: null,
       message: effectiveSettings.showPromptPreview === false ? 'Batch sent directly to AI.' : 'Batch ready for prompt preview.',
       error: null
     });
@@ -483,7 +760,10 @@ async function resumeBatchScrape(batch) {
       isActive: false,
       error: error.message,
       message: `Error: ${error.message}`,
-      percentage: -1
+      percentage: -1,
+      phase: 'error',
+      status: 'error',
+      batch: null
     });
     throw error;
   } finally {
@@ -502,7 +782,6 @@ async function handleBatchScrapeRequest(request, _sender) {
     threads: [],
     filters: request.filters || {},
     includeHidden: request.includeHidden,
-    localSummarize: request.localSummarize,
     request: request
   };
 
@@ -515,10 +794,13 @@ async function handleBatchScrapeRequest(request, _sender) {
 // Preview / Paste Handoff
 // =====================
 
-async function savePreviewData(data, settings) {
+async function savePreviewData(data, settings, extra = {}) {
   const payload = {
     data,
     settings,
+    // `historyId` lets the preview page's direct-API response be written back onto
+    // the matching history entry; it is null whenever history saving is off.
+    historyId: extra.historyId || null,
     timestamp: Date.now(),
     handoffId: createId(),
     storageOption: settings.dataStorageOption,
@@ -526,12 +808,23 @@ async function savePreviewData(data, settings) {
   };
   const area = getStorageArea(settings.dataStorageOption);
   const otherArea = getOtherStorageArea(settings.dataStorageOption);
-  await setStorage(area, { [PREVIEW_STORAGE_KEY]: payload });
-  if (otherArea !== area) {
-    await removeStorage(otherArea, [PREVIEW_STORAGE_KEY, PASTE_STORAGE_KEY, LEGACY_THREAD_KEY]);
+  let effectiveArea = area;
+  try {
+    await setStorage(area, { [PREVIEW_STORAGE_KEY]: payload });
+  } catch (error) {
+    // Session storage has a small quota; fall back to local rather than losing the handoff.
+    if (area === chrome.storage.local) throw error;
+    console.warn('Reddit to AI: Preview payload write failed, falling back to local storage:', error);
+    effectiveArea = chrome.storage.local;
+    await setStorage(chrome.storage.local, { [PREVIEW_STORAGE_KEY]: payload });
+  }
+  if (otherArea && otherArea !== effectiveArea) {
+    await removeStorage(otherArea, [PREVIEW_STORAGE_KEY, PASTE_STORAGE_KEY, LEGACY_THREAD_KEY])
+      .catch(error => console.warn('Reddit to AI: Failed to clear stale storage area:', error));
   }
   if (settings.dataStorageOption === 'persistent') {
-    await setStorage(chrome.storage.local, { [LEGACY_THREAD_KEY]: data });
+    await setStorage(chrome.storage.local, { [LEGACY_THREAD_KEY]: data })
+      .catch(error => console.warn('Reddit to AI: Failed to persist legacy thread copy:', error));
   }
   return payload;
 }
@@ -682,27 +975,7 @@ function mergeCommentsIntoData(data, comments) {
 }
 
 function mergeAdditionalComments(roots, additionalComments, threadId) {
-  const commentMap = buildCommentMap(roots);
-  const rootIds = new Set((roots || []).map(comment => comment?.id).filter(Boolean));
-  let addedCount = 0;
-  for (const comment of additionalComments || []) {
-    if (!comment || commentMap[comment.id]) continue;
-    comment.replies = Array.isArray(comment.replies) ? comment.replies : [];
-    if (commentMap[comment.parentId]) {
-      commentMap[comment.parentId].replies.push(comment);
-    } else if (comment.parentId === threadId) {
-      roots.push(comment);
-      rootIds.add(comment.id);
-    } else {
-      roots.push(comment);
-      rootIds.add(comment.id);
-    }
-    commentMap[comment.id] = comment;
-    indexCommentTree(comment, commentMap);
-    reparentRootChildren(comment, roots, rootIds, commentMap);
-    addedCount += 1;
-  }
-  return { roots, addedCount };
+  return R2AIRedditParser.mergeAdditionalComments(roots, additionalComments, threadId);
 }
 
 // =====================
@@ -784,8 +1057,11 @@ async function resendHistoryItem(historyId, aiProvider) {
   const item = await getHistoryItem(historyId);
   if (!item) throw new Error('History item not found');
   const settings = await loadSettings();
+  // The provider ride-alongs in the preview payload only. Persisting it here used to
+  // silently rewrite the user's default provider every time they resent a history
+  // item; preview.js reads `settings.selectedLlmProvider` off this payload and sends
+  // its own `aiProvider` back, so the override applies without touching storage.sync.
   const mergedSettings = { ...settings, selectedLlmProvider: aiProvider || settings.selectedLlmProvider };
-  await chrome.storage.sync.set({ selectedLlmProvider: mergedSettings.selectedLlmProvider });
   const scrapeData = {
     post: item.post,
     comments: item.comments,
@@ -799,7 +1075,7 @@ async function resendHistoryItem(historyId, aiProvider) {
     threadUrl: item.threadUrl,
     timestamp: Date.now()
   };
-  await savePreviewData(scrapeData, { ...mergedSettings, dataStorageOption: 'sessionOnly' });
+  await savePreviewData(scrapeData, { ...mergedSettings, dataStorageOption: 'sessionOnly' }, { historyId: item.id });
   await openPreviewTab();
   return { success: true };
 }
@@ -941,6 +1217,181 @@ function resolveSubredditSettings(subreddit, settings) {
 }
 
 // =====================
+// Direct API mode
+// =====================
+//
+// Keys are read from chrome.storage.local and never from chrome.storage.sync: sync
+// replicates through Google's servers and has a small per-item quota. They are held
+// only for the lifetime of a single request, are placed exclusively in request
+// headers, and are never logged, never written into the preview/paste payloads and
+// never included in the settings export (which only walks a sync-key allowlist).
+
+async function getDirectApiConfig() {
+  const result = await getStorage(chrome.storage.local, DIRECT_API_CONFIG_KEY);
+  const stored = result?.[DIRECT_API_CONFIG_KEY];
+  return stored && typeof stored === 'object' ? stored : {};
+}
+
+async function getDirectApiProviderConfig(provider) {
+  const config = await getDirectApiConfig();
+  const entry = config[provider];
+  return {
+    apiKey: typeof entry?.apiKey === 'string' ? entry.apiKey : '',
+    model: typeof entry?.model === 'string' ? entry.model : ''
+  };
+}
+
+// Reports which providers are usable without ever handing a key back to a page.
+async function getDirectApiStatus() {
+  const config = await getDirectApiConfig();
+  const providers = {};
+  for (const provider of R2AIApiProviders.PROVIDER_IDS) {
+    const entry = config[provider];
+    const definition = R2AIApiProviders.PROVIDERS[provider];
+    providers[provider] = {
+      id: provider,
+      label: definition.label,
+      configured: Boolean(typeof entry?.apiKey === 'string' && entry.apiKey.trim()),
+      model: R2AIApiProviders.resolveModel(provider, entry?.model),
+      defaultModel: definition.defaultModel,
+      suggestedModels: definition.suggestedModels
+    };
+  }
+  return { providers };
+}
+
+/**
+ * Performs one provider call. Returns `{ ok: true, payload }` on HTTP 2xx or
+ * `{ ok: false, status, payload }` otherwise, so the caller decides how to map it.
+ * Network faults and the abort timeout are surfaced as thrown errors.
+ */
+async function performApiFetch(request, timeoutMs) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs || R2AIApiProviders.REQUEST_TIMEOUT_MS);
+  let response;
+  try {
+    response = await fetch(request.url, {
+      method: request.method,
+      headers: request.headers,
+      body: JSON.stringify(request.body),
+      signal: controller.signal
+    });
+  } catch (error) {
+    if (error?.name === 'AbortError') {
+      throw new Error('The AI provider did not respond in time. Try again or use a smaller prompt.');
+    }
+    // Deliberately does not echo the request: the headers hold the API key.
+    throw new Error(`Could not reach the AI provider: ${error?.message || 'network error'}`);
+  } finally {
+    clearTimeout(timer);
+  }
+
+  let payload = null;
+  try {
+    payload = await response.json();
+  } catch {
+    payload = null;
+  }
+  return { ok: response.ok, status: response.status, payload };
+}
+
+/**
+ * Sends `promptText` to the configured provider and returns the assistant's reply.
+ * Runs entirely inside the originating message's promise chain so the pending fetch
+ * keeps the service worker alive for the full timeout window.
+ */
+async function callDirectApi(provider, promptText, options = {}) {
+  if (!R2AIApiProviders.isSupportedProvider(provider)) {
+    throw new Error(`Unknown direct API provider: ${provider}`);
+  }
+  const stored = await getDirectApiProviderConfig(provider);
+  const apiKey = options.apiKey || stored.apiKey;
+  if (!apiKey) {
+    throw new Error(`No API key is configured for ${R2AIApiProviders.PROVIDERS[provider].label}. Add one in the extension options.`);
+  }
+  const model = options.model || stored.model;
+  const maxTokens = options.maxTokens;
+
+  const startedAt = Date.now();
+  let request = R2AIApiProviders.buildRequest(provider, { apiKey, model, promptText, maxTokens });
+  let result = await performApiFetch(request, options.timeoutMs);
+
+  // Older OpenAI models reject `max_completion_tokens`; retry once with `max_tokens`.
+  if (!result.ok && R2AIApiProviders.isMaxTokensParamError(provider, result.status, result.payload)) {
+    request = R2AIApiProviders.buildRequest(provider, {
+      apiKey,
+      model,
+      promptText,
+      maxTokens,
+      legacyMaxTokens: true
+    });
+    result = await performApiFetch(request, options.timeoutMs);
+  }
+
+  if (!result.ok) {
+    const mapped = R2AIApiProviders.mapError(provider, result.status, result.payload);
+    const error = new Error(mapped.message);
+    error.retryable = mapped.retryable;
+    error.status = mapped.status;
+    error.providerErrorType = mapped.type;
+    throw error;
+  }
+
+  const parsed = R2AIApiProviders.parseResponse(provider, result.payload);
+  return {
+    provider,
+    model: R2AIApiProviders.resolveModel(provider, model),
+    text: parsed.text,
+    refused: parsed.refused,
+    truncated: parsed.truncated,
+    stopReason: parsed.stopReason,
+    durationMs: Date.now() - startedAt,
+    receivedAt: Date.now()
+  };
+}
+
+async function sendPromptViaApi(request) {
+  const provider = request.apiProvider;
+  const promptText = String(request.promptText || '');
+  const result = await callDirectApi(provider, promptText);
+
+  // Persist alongside the history entry when history saving is on. A failure here
+  // must not lose the response the user is waiting on, so it is logged and ignored.
+  const historyId = request.historyId || (await getPreviewData())?.historyId || null;
+  if (historyId) {
+    try {
+      await updateHistoryItem(historyId, {
+        apiResponse: {
+          provider: result.provider,
+          model: result.model,
+          text: result.text,
+          refused: result.refused,
+          truncated: result.truncated,
+          receivedAt: result.receivedAt
+        }
+      });
+    } catch (error) {
+      console.warn('Reddit to AI: Could not attach the API response to history:', error.message);
+    }
+  }
+
+  return { success: true, response: result };
+}
+
+// Minimal round-trip used by the options page "Test key" buttons. The key comes from
+// the options form so a user can verify it before saving.
+async function testDirectApiKey(request) {
+  const provider = request.apiProvider;
+  const result = await callDirectApi(provider, 'Say OK', {
+    apiKey: request.apiKey,
+    model: request.model,
+    maxTokens: 16,
+    timeoutMs: 30000
+  });
+  return { success: true, model: result.model, text: result.text };
+}
+
+// =====================
 // Storage / Settings
 // =====================
 
@@ -1000,33 +1451,51 @@ function getOtherStorageArea(option) {
   return option === 'persistent' ? (chrome.storage.session || null) : chrome.storage.local;
 }
 
+function getStorageError() {
+  const lastError = chrome.runtime?.lastError;
+  if (!lastError) return null;
+  return new Error(lastError.message || 'chrome.storage operation failed.');
+}
+
 function getStorage(area, keys) {
-  return new Promise(resolve => {
+  return new Promise((resolve, reject) => {
     if (!area) {
       resolve({});
       return;
     }
-    area.get(keys, result => resolve(result || {}));
+    area.get(keys, result => {
+      const error = getStorageError();
+      if (error) reject(error);
+      else resolve(result || {});
+    });
   });
 }
 
 function setStorage(area, items) {
-  return new Promise(resolve => {
+  return new Promise((resolve, reject) => {
     if (!area) {
       resolve();
       return;
     }
-    area.set(items, () => resolve());
+    area.set(items, () => {
+      const error = getStorageError();
+      if (error) reject(error);
+      else resolve();
+    });
   });
 }
 
 function removeStorage(area, keys) {
-  return new Promise(resolve => {
+  return new Promise((resolve, reject) => {
     if (!area) {
       resolve();
       return;
     }
-    area.remove(keys, () => resolve());
+    area.remove(keys, () => {
+      const error = getStorageError();
+      if (error) reject(error);
+      else resolve();
+    });
   });
 }
 
@@ -1036,7 +1505,17 @@ function removeStorage(area, keys) {
 
 function setScrapingState(patch) {
   scrapingState = { ...scrapingState, ...patch };
+  persistScrapingState();
   broadcastScrapingState();
+}
+
+// The state object is a handful of scalars, so mirroring it into storage.session on
+// every change is cheap and lets a woken worker answer `getScrapingState` correctly.
+// Fire and forget: a failed mirror must never break the scrape itself.
+function persistScrapingState() {
+  if (!chrome.storage.session) return;
+  setStorage(chrome.storage.session, { [SCRAPING_STATE_KEY]: scrapingState })
+    .catch(error => console.debug('Scraping state persist skipped:', error.message));
 }
 
 function broadcastScrapingState() {
@@ -1055,8 +1534,11 @@ function broadcastScrapingState() {
   }
 }
 
-function stopActiveScrape() {
-  removeStorage(chrome.storage.local, ['activeBatch']);
+async function stopActiveScrape() {
+  // Awaited so a stop cannot lose a race with the auto-resume on the next wake-up.
+  await removeStorage(chrome.storage.local, ['activeBatch'])
+    .catch(error => console.warn('Reddit to AI: Failed to clear activeBatch:', error));
+  await clearScrapeContext();
   if (!currentScrape) return;
   currentScrape.stopRequested = true;
   setScrapingState({ message: chrome.i18n.getMessage('sw_status_stop_requested') || 'Stop requested.', percentage: scrapingState.percentage });
@@ -1070,10 +1552,25 @@ function stopActiveScrape() {
   }
 }
 
+// Tab URLs are only readable where the extension has a permission for them: a
+// Reddit tab is covered by host_permissions, and the tab that was active when the
+// user clicked the action is covered by activeTab. The broad `tabs` permission is
+// deliberately not requested, so when the active tab's URL comes back empty we
+// retry with a Reddit-scoped match pattern instead of assuming we may read it.
+const REDDIT_TAB_MATCHES = ['*://*.reddit.com/*', 'https://*.redd.it/*'];
+
 async function getActiveTab() {
   const tabs = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
-  if (!tabs || tabs.length === 0) throw new Error('No active tab detected.');
-  return tabs[0];
+  const activeTab = tabs && tabs[0];
+  if (activeTab && getTabUrl(activeTab)) return activeTab;
+
+  const redditTabs = await chrome.tabs
+    .query({ active: true, lastFocusedWindow: true, url: REDDIT_TAB_MATCHES })
+    .catch(() => []);
+  if (redditTabs && redditTabs[0]) return redditTabs[0];
+
+  if (activeTab) return activeTab;
+  throw new Error('No active tab detected.');
 }
 
 async function getScrapeTargetTab(request, sender) {
@@ -1150,28 +1647,28 @@ async function injectContentScripts(tabId) {
     console.debug('Floating panel script injection skipped:', error.message);
   }
 
-  try {
-    await chrome.scripting.executeScript({ target: { tabId }, files: ['cl100k_base.js'] });
-  } catch (error) {
-    console.debug('cl100k_base helper injection skipped:', error.message);
-  }
-
+  // cl100k_base.js is intentionally not injected here: nothing on a Reddit tab asks
+  // for exact token counts, and promptBuilder falls back to a length / 4 estimate.
   try {
     await chrome.scripting.executeScript({ target: { tabId }, files: ['promptBuilder.js'] });
   } catch (error) {
     console.debug('Prompt helper injection skipped:', error.message);
   }
 
+  // redditScraper.js parses through R2AIRedditParser, so this injection is not
+  // optional; let a failure surface instead of scraping with a missing dependency.
+  await chrome.scripting.executeScript({ target: { tabId }, files: ['redditParser.js'] });
   await chrome.scripting.executeScript({ target: { tabId }, files: ['redditScraper.js'] });
 }
 
-async function requestScrapeFromTab(tabId, includeHidden, filters) {
+async function requestScrapeFromTab(tabId, includeHidden, filters, scrapeId) {
+  const message = { action: 'scrapeReddit', includeHidden, filters, scrapeId };
   try {
-    return await sendMessageToTab(tabId, { action: 'scrapeReddit', includeHidden, filters });
+    return await sendMessageToTab(tabId, message);
   } catch (error) {
     if (/Receiving end does not exist/.test(error.message)) {
       await delay(250);
-      return sendMessageToTab(tabId, { action: 'scrapeReddit', includeHidden, filters });
+      return sendMessageToTab(tabId, message);
     }
     throw error;
   }
@@ -1190,6 +1687,7 @@ function sendMessageToTab(tabId, message) {
 }
 
 function showNotificationIfEnabled(title, message, notificationIdBase = 'reddit-to-ai') {
+  if (!chrome.notifications?.create) return;
   chrome.storage.sync.get(['showNotifications'], result => {
     const shouldShow = typeof result.showNotifications === 'boolean' ? result.showNotifications : true;
     if (!shouldShow) return;
@@ -1224,7 +1722,12 @@ async function getAiUrl(providerKey) {
       }
       return match;
     }
-    return 'http://localhost:3000/';
+    // No custom origin configured: opening a hard-coded localhost URL silently sent
+    // users to a page that almost never exists. Surface the misconfiguration instead.
+    const message = chrome.i18n.getMessage('sw_error_custom_origin_missing')
+      || 'No custom AI origin is configured. Add one in Options before using the custom provider.';
+    showNotificationIfEnabled(chrome.i18n.getMessage('extName') || 'Reddit to AI', message);
+    throw new Error(message);
   }
   return map[providerKey] || map.gemini;
 }
@@ -1348,51 +1851,7 @@ function inferThreadId(data) {
 
 function countComments(comments) {
   if (globalThis.R2AIPrompt?.countComments) return R2AIPrompt.countComments(comments);
-  if (!Array.isArray(comments)) return 0;
-  let total = 0;
-  const stack = [...comments];
-  while (stack.length > 0) {
-    const next = stack.pop();
-    if (!next) continue;
-    total += 1;
-    if (Array.isArray(next.replies)) stack.push(...next.replies);
-  }
-  return total;
-}
-
-function buildCommentMap(roots) {
-  const map = {};
-  const traverse = comments => {
-    for (const comment of comments || []) {
-      if (comment?.id) map[comment.id] = comment;
-      traverse(comment.replies || []);
-    }
-  };
-  traverse(roots);
-  return map;
-}
-
-function indexCommentTree(comment, map) {
-  if (!comment?.id) return;
-  map[comment.id] = comment;
-  for (const reply of comment.replies || []) {
-    indexCommentTree(reply, map);
-  }
-}
-
-function reparentRootChildren(parent, roots, rootIds, commentMap) {
-  if (!parent?.id) return;
-  for (let i = roots.length - 1; i >= 0; i--) {
-    const candidate = roots[i];
-    if (!candidate || candidate.id === parent.id || candidate.parentId !== parent.id) continue;
-    roots.splice(i, 1);
-    rootIds.delete(candidate.id);
-    if (!parent.replies.some(reply => reply.id === candidate.id)) {
-      parent.replies.unshift(candidate);
-    }
-  }
-  rootIds.delete(parent.id);
-  indexCommentTree(parent, commentMap);
+  return R2AIRedditParser.countComments(comments);
 }
 
 function inferSubredditFromUrl(url) {
@@ -1454,14 +1913,7 @@ async function scrapeThreadFromUrl(url, settings, filters) {
 }
 
 function buildRedditJsonUrl(inputUrl, sortMode, depth) {
-  const url = new URL(inputUrl);
-  url.pathname = url.pathname.replace(/\/$/, '') + '.json';
-  url.searchParams.set('limit', '500');
-  url.searchParams.set('depth', String(Math.min(Math.max(depth, 1), 10)));
-  url.searchParams.set('raw_json', '1');
-  url.searchParams.set('showmore', 'true');
-  url.searchParams.set('sort', sortMode || 'confidence');
-  return url.toString();
+  return R2AIRedditParser.buildRedditJsonUrl(inputUrl, sortMode, depth);
 }
 
 async function fetchJsonWithRetry(url, retries = 3) {
@@ -1537,96 +1989,32 @@ function enqueueMoreIds(ids, queue, seenIds) {
 }
 
 function parseBackgroundComments(children, includeHidden, maxDepth, moreIds) {
-  const roots = [];
-  for (const child of children || []) {
-    const node = parseBackgroundCommentNode(child, includeHidden, 0, maxDepth, moreIds);
-    if (node) roots.push(node);
-  }
-  return roots;
+  return R2AIRedditParser.parseComments(children, {
+    includeHidden,
+    maxDepth,
+    moreIds,
+    placeholderStyle: 'background'
+  }).roots;
 }
 
 function parseBackgroundCommentNode(child, includeHidden, depth, maxDepth, moreIds) {
-  if (child.kind === 'more' && Array.isArray(child.data?.children)) {
-    moreIds.push(...child.data.children);
-    return null;
-  }
-  if (child.kind !== 't1') return null;
-  const replies = [];
-  const replyChildren = child.data?.replies?.data?.children;
-  if (depth < maxDepth - 1 && replyChildren) {
-    for (const reply of replyChildren) {
-      const parsed = parseBackgroundCommentNode(reply, includeHidden, depth + 1, maxDepth, moreIds);
-      if (parsed) replies.push(parsed);
-    }
-  }
-
-  const comment = parseBackgroundCommentData(child.data, includeHidden, replies);
-  if (!comment) return replies.length > 0 ? createOmittedParentPlaceholder(child.data, replies) : null;
-  comment.replies = replies;
-  return comment;
+  return R2AIRedditParser.parseCommentNode(
+    child,
+    { includeHidden, maxDepth, moreIds, placeholderStyle: 'background' },
+    depth
+  );
 }
 
 function parseBackgroundCommentData(data, includeHidden, replies = []) {
-  const isRemoved = data?.body === '[removed]' || data?.body === '[deleted]';
-  if (!includeHidden && isRemoved) return null;
-  return {
-    id: data.name,
-    parentId: data.parent_id,
-    author: data.author,
-    text: data.body || '',
-    score: data.score,
-    controversiality: data.controversiality || 0,
-    timestamp: data.created_utc ? data.created_utc * 1000 : null,
-    isSubmitter: data.is_submitter || false,
-    authorFlair: data.author_flair_text || null,
-    distinguished: data.distinguished || null,
-    awardCount: data.total_awards_received || 0,
-    permalink: data.permalink ? `https://www.reddit.com${data.permalink}` : null,
-    replies
-  };
-}
-
-function createOmittedParentPlaceholder(data, replies) {
-  return {
-    id: data.name,
-    parentId: data.parent_id,
-    author: '[omitted]',
-    text: '[removed/deleted parent omitted]',
-    score: data.score || 0,
-    controversiality: data.controversiality || 0,
-    timestamp: data.created_utc ? data.created_utc * 1000 : null,
-    isSubmitter: false,
-    authorFlair: null,
-    distinguished: null,
-    awardCount: data.total_awards_received || 0,
-    permalink: data.permalink ? `https://www.reddit.com${data.permalink}` : null,
-    isOmittedParent: true,
-    replies
-  };
+  return R2AIRedditParser.parseCommentData(data, includeHidden, replies);
 }
 
 function applyBackgroundFilters(comments, filters, settings) {
-  const minScore = filters.minScore || 0;
-  const hideBots = Boolean(filters.hideBots);
-  const authorTypes = Array.isArray(filters.authorTypes) ? filters.authorTypes : [];
-  const shouldInclude = comment => {
-    if (comment.isOmittedParent) return true;
-    if (minScore > 0 && (comment.score || 0) < minScore) return false;
-    if (hideBots && String(comment.author || '').toLowerCase().endsWith('bot')) return false;
-    if (authorTypes.length > 0) {
-      const matchesOp = authorTypes.includes('op') && comment.isSubmitter;
-      const matchesFlaired = authorTypes.includes('flaired') && comment.authorFlair;
-      if (!matchesOp && !matchesFlaired) return false;
-    }
-    return true;
-  };
-  const filterTree = nodes => (nodes || []).flatMap(node => {
-    const replies = filterTree(node.replies || []);
-    if (node.isOmittedParent && replies.length === 0) return [];
-    if (!shouldInclude(node)) return replies;
-    return [{ ...node, replies }];
+  let result = R2AIRedditParser.filterComments(comments, {
+    minScore: filters.minScore || 0,
+    hideBots: Boolean(filters.hideBots),
+    authorTypes: Array.isArray(filters.authorTypes) ? filters.authorTypes : []
   });
-  let result = filterTree(comments);
   const topN = filters.topN || 0;
   if (topN > 0 && globalThis.R2AIPrompt?.trimComments) {
     result = R2AIPrompt.trimComments(result, topN, filters.trimStrategy || settings.trimStrategy || 'top');
@@ -1693,6 +2081,37 @@ function delay(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+const KNOWN_SELECTOR_PLATFORMS = ['gemini', 'chatgpt', 'claude', 'aistudio', 'deepseek', 'groq', 'custom'];
+const SELECTOR_STRING_FIELDS = ['inputSelector'];
+const SELECTOR_BOOLEAN_FIELDS = ['isContentEditable'];
+
+// Accepts only known platform keys with string selectors / boolean flags.
+// Anything else (unknown platforms, non-string selectors, metadata such as `version`) is skipped.
+function sanitizeSyncedSelectors(raw) {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+  const clean = {};
+  for (const platform of KNOWN_SELECTOR_PLATFORMS) {
+    const value = raw[platform];
+    if (value === undefined || value === null) continue;
+
+    if (typeof value === 'string') {
+      if (value.trim()) clean[platform] = value;
+      continue;
+    }
+    if (typeof value !== 'object' || Array.isArray(value)) continue;
+
+    const entry = {};
+    for (const field of SELECTOR_STRING_FIELDS) {
+      if (typeof value[field] === 'string' && value[field].trim()) entry[field] = value[field];
+    }
+    for (const field of SELECTOR_BOOLEAN_FIELDS) {
+      if (typeof value[field] === 'boolean') entry[field] = value[field];
+    }
+    if (Object.keys(entry).length > 0) clean[platform] = entry;
+  }
+  return Object.keys(clean).length > 0 ? clean : null;
+}
+
 async function syncSelectors() {
   try {
     const url = 'https://raw.githubusercontent.com/KhazP/Reddit-to-AI/main/selectors.json';
@@ -1700,8 +2119,11 @@ async function syncSelectors() {
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`);
     }
-    const selectors = await response.json();
-    if (selectors && typeof selectors === 'object') {
+    const raw = await response.json();
+    const selectors = sanitizeSyncedSelectors(raw);
+    if (!selectors) {
+      console.warn('Reddit to AI: Remote selectors payload had no usable entries; skipping.');
+    } else {
       await new Promise(resolve => {
         chrome.storage.local.set({
           syncedSelectors: selectors,
@@ -1743,84 +2165,12 @@ if (chrome.runtime.onStartup) {
   });
 }
 
-/**
- * Checks if the browser has built-in Gemini Nano / Local AI capability enabled.
- */
-async function checkLocalAiCapability() {
-  try {
-    const aiObj = typeof self !== 'undefined' && self.ai ? self.ai : (typeof ai !== 'undefined' ? ai : null);
-    if (!aiObj) return false;
-    
-    if (aiObj.languageModel) {
-      const caps = await aiObj.languageModel.capabilities();
-      return caps && caps.available !== 'no';
-    }
-    if (aiObj.assistant) {
-      const caps = await aiObj.assistant.capabilities();
-      return caps && caps.available !== 'no';
-    }
-  } catch (e) {
-    console.error('Error checking local AI capability:', e);
-  }
-  return false;
-}
 
-/**
- * Generates summary using Local AI Prompt API with streaming progress callbacks.
- */
-async function generateLocalSummary(promptText, onChunk) {
-  const aiObj = typeof self !== 'undefined' && self.ai ? self.ai : (typeof ai !== 'undefined' ? ai : null);
-  if (!aiObj) {
-    throw new Error('Chrome Local AI (ai) is not supported in this environment.');
-  }
 
-  let modelApi = aiObj.languageModel;
-  if (!modelApi && aiObj.assistant) {
-    modelApi = aiObj.assistant;
-  }
-
-  if (!modelApi) {
-    throw new Error('Chrome Local AI languageModel/assistant API is not available.');
-  }
-
-  const caps = await modelApi.capabilities();
-  if (!caps || caps.available === 'no') {
-    throw new Error('Chrome Local AI is not available (capabilities returned "no").');
-  }
-
-  const session = await modelApi.create();
-  try {
-    if (typeof session.promptStreaming === 'function') {
-      const stream = session.promptStreaming(promptText);
-      let fullText = '';
-      for await (const chunk of stream) {
-        fullText = chunk;
-        if (typeof onChunk === 'function') {
-          onChunk(fullText);
-        }
-      }
-      return fullText;
-    } else {
-      const result = await session.prompt(promptText);
-      if (typeof onChunk === 'function') {
-        onChunk(result);
-      }
-      return result;
-    }
-  } finally {
-    try {
-      if (typeof session.destroy === 'function') {
-        session.destroy();
-      } else if (typeof session.close === 'function') {
-        session.close();
-      }
-    } catch (e) {
-      console.debug('Error closing AI session:', e);
-    }
-  }
-}
-
-// Simple cache for quick estimates
+// Simple cache for quick estimates. Entries are `{ data, timestamp }` and expire
+// after QUICK_ESTIMATE_TTL_MS so a thread that keeps growing is not estimated from
+// a stale snapshot for the whole life of the worker.
+const QUICK_ESTIMATE_TTL_MS = 5 * 60 * 1000;
 const quickEstimateCache = new Map();
 
 // Helper to check if URL is a Reddit post
@@ -1866,8 +2216,12 @@ async function getQuickTokenEstimate(tabId, urlStr) {
   if (!isRedditPostUrl(urlStr)) {
     throw new Error('Not a Reddit post URL.');
   }
-  if (quickEstimateCache.has(urlStr)) {
-    return quickEstimateCache.get(urlStr);
+  const cached = quickEstimateCache.get(urlStr);
+  if (cached) {
+    if (Date.now() - (cached.timestamp || 0) < QUICK_ESTIMATE_TTL_MS) {
+      return cached.data;
+    }
+    quickEstimateCache.delete(urlStr);
   }
 
   // Construct JSON URL
@@ -1915,7 +2269,7 @@ async function getQuickTokenEstimate(tabId, urlStr) {
     const oldestKey = quickEstimateCache.keys().next().value;
     quickEstimateCache.delete(oldestKey);
   }
-  quickEstimateCache.set(urlStr, estimatedData);
+  quickEstimateCache.set(urlStr, { data: estimatedData, timestamp: Date.now() });
   return estimatedData;
 }
 
@@ -1936,9 +2290,8 @@ if (globalThis.R2AIServiceWorkerTest) {
     parseBackgroundComments,
     parseBackgroundCommentNode,
     syncSelectors,
+    sanitizeSyncedSelectors,
     checkAndSyncSelectors,
-    checkLocalAiCapability,
-    generateLocalSummary,
     getScriptIdForOrigin,
     registerCustomOriginScript,
     unregisterCustomOriginScript,
@@ -1949,6 +2302,13 @@ if (globalThis.R2AIServiceWorkerTest) {
     PRESET_TEMPLATES,
     resumeBatchScrape,
     handleBatchScrapeRequest,
+    handleScrapeRequest,
+    handleRuntimeMessage,
+    finishTabScrape,
+    getActiveScrapeContext,
+    ready,
+    SCRAPE_CONTEXT_KEY,
+    SCRAPING_STATE_KEY,
     stopActiveScrape,
     getScrapingState: () => scrapingState,
     setScrapingState,
@@ -1957,6 +2317,18 @@ if (globalThis.R2AIServiceWorkerTest) {
     getQuickTokenEstimate,
     addToHistory,
     resendHistoryItem,
+    updateHistoryItem,
+    getHistory,
+    getDirectApiConfig,
+    getDirectApiStatus,
+    callDirectApi,
+    sendPromptViaApi,
+    testDirectApiKey,
+    DIRECT_API_CONFIG_KEY,
+    getStorage,
+    setStorage,
+    removeStorage,
+    savePreviewData,
     chrome: typeof chrome !== 'undefined' ? chrome : null
   });
 }

--- a/src/tooltip.css
+++ b/src/tooltip.css
@@ -1,30 +1,39 @@
+/* Reddit to AI — Tooltip ("Ember" design system)
+   Injected into pages — colors hard-coded, no :root vars. */
+
 .tooltip-bubble {
   position: absolute;
   z-index: 9999;
-  background: #18181b;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 6px;
+  background: #232329;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 8px;
   padding: 6px 10px;
-  color: #f8fafc;
+  color: #f4f4f5;
   font-size: 11px;
   line-height: 1.4;
   max-width: 220px;
   pointer-events: none;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
   opacity: 0;
-  transform: translateY(4px) scale(0.95);
-  transition: opacity 150ms ease, transform 150ms cubic-bezier(0.16, 1, 0.3, 1);
+  transform: translateY(4px) scale(0.97);
+  transition: opacity 150ms cubic-bezier(0.4, 0, 0.2, 1), transform 150ms cubic-bezier(0.16, 1, 0.3, 1);
 }
+
 .tooltip-bubble.visible {
   opacity: 1;
   transform: translateY(0) scale(1);
 }
+
 .tooltip-arrow {
   position: absolute;
   width: 6px;
   height: 6px;
-  background: #18181b;
-  border-right: 1px solid rgba(255, 255, 255, 0.08);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  background: #232329;
+  border-right: 1px solid rgba(255, 255, 255, 0.14);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.14);
   transform: rotate(45deg);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tooltip-bubble { transition: none; }
 }

--- a/tests/aiPasterImagePaste.test.mjs
+++ b/tests/aiPasterImagePaste.test.mjs
@@ -3,9 +3,12 @@ import { readFile } from 'node:fs/promises';
 import vm from 'node:vm';
 
 class FakeTextArea {
-  constructor() {
+  // pasteDispatchResult mirrors DOM semantics: dispatchEvent() returns false when a
+  // listener called preventDefault(), i.e. when the site consumed the pasted image.
+  constructor({ pasteDispatchResult = false } = {}) {
     this.value = '';
     this.events = [];
+    this.pasteDispatchResult = pasteDispatchResult;
   }
 
   focus() {
@@ -14,6 +17,7 @@ class FakeTextArea {
 
   dispatchEvent(event) {
     this.events.push(event);
+    if (event?.type === 'paste') return this.pasteDispatchResult;
     return true;
   }
 }
@@ -42,8 +46,8 @@ function createElement(tagName = 'div') {
   };
 }
 
-function createContext({ imageResponses }) {
-  const input = new FakeTextArea();
+function createContext({ imageResponses, pasteDispatchResult = false }) {
+  const input = new FakeTextArea({ pasteDispatchResult });
   const runtimeMessages = [];
   const body = createElement('body');
   body.innerText = 'Ready';
@@ -197,3 +201,35 @@ const okImage = { base64: Buffer.from('image-bytes').toString('base64'), mimeTyp
   assert.ok(!runtimeMessages.some(message => message.action === 'markPendingPasteConsumed'));
   assert.equal(context.sessionStorage.getItem('redditToAiPastedId'), null);
 }
+
+// dispatchEvent() returning false (preventDefault -> site consumed the image) counts as pasted.
+{
+  const { context, input } = createContext({
+    imageResponses: { 'https://example.test/one.png': okImage },
+    pasteDispatchResult: false
+  });
+  const api = await loadAiPaster(context);
+  const result = await api.pasteImages(input, ['https://example.test/one.png']);
+  assert.deepEqual(
+    { attempted: result.attempted, fetched: result.fetched, pasted: result.pasted },
+    { attempted: 1, fetched: 1, pasted: 1 }
+  );
+  assert.equal(result.failures.length, 0);
+}
+
+// dispatchEvent() returning true means no listener consumed the paste -> unverified.
+{
+  const { context, input } = createContext({
+    imageResponses: { 'https://example.test/one.png': okImage },
+    pasteDispatchResult: true
+  });
+  const api = await loadAiPaster(context);
+  const result = await api.pasteImages(input, ['https://example.test/one.png']);
+  assert.equal(result.fetched, 1);
+  assert.equal(result.pasted, 0);
+  assert.equal(result.failures.length, 1);
+  assert.equal(result.failures[0].phase, 'paste');
+  assert.match(result.failures[0].reason, /No paste handler detected/);
+}
+
+console.log('AI Paster image paste unit tests passed!');

--- a/tests/aiPasterTargetSelection.test.mjs
+++ b/tests/aiPasterTargetSelection.test.mjs
@@ -1,0 +1,159 @@
+// Covers paste-target selection: the composer is chosen by scoring every visible
+// match rather than taking the first querySelector hit, and login detection only
+// runs after the composer search has actually failed.
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import vm from 'node:vm';
+
+const VIEWPORT_HEIGHT = 900;
+
+// A minimal element good enough for the scorer: attributes, a class name, and a box.
+function makeEl({
+  tagName = 'div',
+  attributes = {},
+  className = '',
+  rect = { width: 600, height: 120, bottom: 860 },
+  offsetParent = {},
+  hidden = false
+} = {}) {
+  return {
+    tagName,
+    className,
+    hidden,
+    offsetParent,
+    attributes,
+    getAttribute(name) {
+      return attributes[name] !== undefined ? String(attributes[name]) : null;
+    },
+    getBoundingClientRect() {
+      return rect;
+    }
+  };
+}
+
+function createContext({ candidates = [], bodyText = 'Ready', href = 'https://claude.ai/new' } = {}) {
+  const context = {
+    console: { log() {}, warn() {}, error() {}, debug() {} },
+    Array,
+    Math,
+    Infinity,
+    String,
+    Promise,
+    Date,
+    setTimeout: (callback, ms) => globalThis.setTimeout(callback, ms),
+    clearTimeout: (id) => globalThis.clearTimeout(id),
+    setInterval: (callback, ms) => globalThis.setInterval(callback, ms),
+    clearInterval: (id) => globalThis.clearInterval(id),
+    location: { href, hostname: new URL(href).hostname },
+    document: {
+      documentElement: null,
+      body: { innerText: bodyText },
+      querySelectorAll: () => candidates,
+      querySelector: () => candidates[0] || null
+    },
+    chrome: {
+      storage: {
+        local: { get(_k, cb) { cb({}); } },
+        sync: { get(_k, cb) { cb({}); } }
+      }
+    },
+    R2AIAiPasterTest: {}
+  };
+  context.window = { location: context.location, innerHeight: VIEWPORT_HEIGHT };
+  return context;
+}
+
+async function loadAiPaster(context) {
+  const source = await readFile(new URL('../src/aiPaster.js', import.meta.url), 'utf8');
+  vm.runInNewContext(source, context, { filename: 'aiPaster.js' });
+  return context.R2AIAiPasterTest;
+}
+
+// 1. A hidden editable that appears first in document order loses to the visible,
+//    properly-labelled composer that follows it. This is the Claude/Gemini bug:
+//    the bare [contenteditable="true"] fallback used to grab the wrong element.
+{
+  const hiddenFirst = makeEl({
+    attributes: { contenteditable: 'true' },
+    rect: { width: 0, height: 0, bottom: 0 },
+    offsetParent: null
+  });
+  const realComposer = makeEl({
+    attributes: { contenteditable: 'true', role: 'textbox', 'aria-label': 'Write your prompt to Claude' },
+    className: 'ProseMirror',
+    rect: { width: 620, height: 140, bottom: 870 }
+  });
+
+  const context = createContext({ candidates: [hiddenFirst, realComposer] });
+  const api = await loadAiPaster(context);
+
+  assert.equal(api.pickBestCandidate('[contenteditable="true"]'), realComposer,
+    'the visible, labelled composer wins over the earlier hidden editable');
+}
+
+// 2. Among two visible editables, the labelled one near the viewport bottom wins
+//    over a small unlabelled box near the top.
+{
+  const strayEditable = makeEl({
+    attributes: { contenteditable: 'true' },
+    rect: { width: 120, height: 24, bottom: 60 }
+  });
+  const composer = makeEl({
+    tagName: 'textarea',
+    attributes: { contenteditable: 'true', 'aria-label': 'Message ChatGPT' },
+    rect: { width: 640, height: 130, bottom: 880 }
+  });
+
+  const context = createContext({ candidates: [strayEditable, composer] });
+  const api = await loadAiPaster(context);
+
+  assert.ok(api.scoreCandidate(composer) > api.scoreCandidate(strayEditable),
+    'the labelled bottom-anchored composer scores higher');
+  assert.equal(api.pickBestCandidate('textarea, [contenteditable="true"]'), composer);
+}
+
+// 3. waitForInput resolves immediately when a viable candidate is already present,
+//    without waiting out any polling schedule.
+{
+  const composer = makeEl({ tagName: 'textarea', attributes: { 'aria-label': 'Send a message' } });
+  const context = createContext({ candidates: [composer] });
+  const api = await loadAiPaster(context);
+
+  const started = Date.now();
+  const found = await api.waitForInput('textarea', 5000);
+  assert.equal(found, composer);
+  assert.ok(Date.now() - started < 250, 'resolves synchronously rather than sleeping');
+}
+
+// 4. With no candidate at all, waitForInput gives up after its timeout budget and
+//    returns null instead of a wrong element.
+{
+  const context = createContext({ candidates: [] });
+  const api = await loadAiPaster(context);
+  const found = await api.waitForInput('textarea', 60);
+  assert.equal(found, null);
+}
+
+// 5. Login detection still works, but it is only reachable from the failure path.
+{
+  const context = createContext({ candidates: [], bodyText: 'Please sign in to continue' });
+  const api = await loadAiPaster(context);
+  assert.match(api.detectLoginRequired(), /sign-in/i);
+
+  const source = await readFile(new URL('../src/aiPaster.js', import.meta.url), 'utf8');
+  const attemptBody = source.slice(source.indexOf('async function attemptPaste'), source.indexOf('function detectLoginRequired'));
+  assert.ok(
+    attemptBody.indexOf('await waitForInput') < attemptBody.indexOf('detectLoginRequired()'),
+    'the composer search runs before login detection'
+  );
+}
+
+// 6. The fixed retry loop is gone in favour of an observer + overall timeout.
+{
+  const source = await readFile(new URL('../src/aiPaster.js', import.meta.url), 'utf8');
+  assert.doesNotMatch(source, /INPUT_RETRY_LIMIT/, 'the fixed poll count is removed');
+  assert.match(source, /MutationObserver/, 'a MutationObserver drives the wait');
+  assert.match(source, /INPUT_WAIT_TIMEOUT = 20000/, 'an overall timeout bounds the wait');
+}
+
+console.log('AI Paster target selection tests passed!');

--- a/tests/apiProviders.test.mjs
+++ b/tests/apiProviders.test.mjs
@@ -1,0 +1,235 @@
+import assert from 'node:assert/strict';
+import '../src/apiProviders.js';
+
+const { R2AIApiProviders } = globalThis;
+
+assert.ok(R2AIApiProviders, 'R2AIApiProviders should be attached to globalThis');
+
+// =====================
+// Request building
+// =====================
+
+// Anthropic: key travels in x-api-key, never in the URL or body.
+{
+  const request = R2AIApiProviders.buildRequest('anthropic', {
+    apiKey: 'sk-ant-fake',
+    promptText: 'Analyze this thread.'
+  });
+  assert.equal(request.url, 'https://api.anthropic.com/v1/messages');
+  assert.equal(request.method, 'POST');
+  assert.equal(request.headers['x-api-key'], 'sk-ant-fake');
+  assert.equal(request.headers['anthropic-version'], '2023-06-01');
+  assert.equal(request.headers['anthropic-dangerous-direct-browser-access'], 'true');
+  assert.equal(request.body.model, 'claude-opus-5', 'default Anthropic model');
+  assert.equal(request.body.max_tokens, 8192);
+  assert.deepEqual(request.body.messages, [{ role: 'user', content: 'Analyze this thread.' }]);
+  assert.ok(!request.url.includes('sk-ant-fake'), 'key must never appear in the URL');
+  assert.ok(!JSON.stringify(request.body).includes('sk-ant-fake'), 'key must never appear in the body');
+}
+
+// A user-typed model overrides the default, so new model ids work without a release.
+{
+  const request = R2AIApiProviders.buildRequest('anthropic', {
+    apiKey: 'k',
+    model: 'claude-sonnet-5',
+    promptText: 'hi'
+  });
+  assert.equal(request.body.model, 'claude-sonnet-5');
+}
+
+// OpenAI: bearer auth, max_completion_tokens by default, legacy max_tokens on retry.
+{
+  const request = R2AIApiProviders.buildRequest('openai', {
+    apiKey: 'sk-openai-fake',
+    promptText: 'hi'
+  });
+  assert.equal(request.url, 'https://api.openai.com/v1/chat/completions');
+  assert.equal(request.headers.authorization, 'Bearer sk-openai-fake');
+  assert.equal(request.body.model, 'gpt-5.2', 'default OpenAI model');
+  assert.equal(request.body.max_completion_tokens, 8192);
+  assert.equal(request.body.max_tokens, undefined);
+
+  const legacy = R2AIApiProviders.buildRequest('openai', {
+    apiKey: 'sk-openai-fake',
+    promptText: 'hi',
+    legacyMaxTokens: true
+  });
+  assert.equal(legacy.body.max_tokens, 8192);
+  assert.equal(legacy.body.max_completion_tokens, undefined);
+}
+
+// Gemini: key in x-goog-api-key header (not a query param), model in the path.
+{
+  const request = R2AIApiProviders.buildRequest('google', {
+    apiKey: 'goog-fake',
+    promptText: 'hi'
+  });
+  assert.equal(
+    request.url,
+    'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent'
+  );
+  assert.equal(request.headers['x-goog-api-key'], 'goog-fake');
+  assert.ok(!request.url.includes('goog-fake'), 'key must never be placed in the URL');
+  assert.deepEqual(request.body, { contents: [{ parts: [{ text: 'hi' }] }] });
+
+  const pro = R2AIApiProviders.buildRequest('google', {
+    apiKey: 'goog-fake',
+    model: 'gemini-2.5-pro',
+    promptText: 'hi'
+  });
+  assert.match(pro.url, /models\/gemini-2\.5-pro:generateContent$/);
+}
+
+// Guard rails.
+{
+  assert.throws(() => R2AIApiProviders.buildRequest('nope', { apiKey: 'k', promptText: 'x' }), /Unknown direct API provider/);
+  assert.throws(() => R2AIApiProviders.buildRequest('anthropic', { apiKey: '  ', promptText: 'x' }), /No API key/);
+  assert.throws(() => R2AIApiProviders.buildRequest('anthropic', { apiKey: 'k', promptText: '   ' }), /Prompt is empty/);
+}
+
+// =====================
+// Response parsing
+// =====================
+
+// Anthropic joins text blocks and skips non-text blocks.
+{
+  const parsed = R2AIApiProviders.parseResponse('anthropic', {
+    stop_reason: 'end_turn',
+    content: [
+      { type: 'text', text: 'First part. ' },
+      { type: 'thinking', thinking: 'ignored' },
+      { type: 'text', text: 'Second part.' }
+    ]
+  });
+  assert.equal(parsed.text, 'First part. Second part.');
+  assert.equal(parsed.refused, false);
+  assert.equal(parsed.truncated, false);
+}
+
+// A refusal is detected from stop_reason before content is read.
+{
+  const parsed = R2AIApiProviders.parseResponse('anthropic', {
+    stop_reason: 'refusal',
+    content: [{ type: 'text', text: 'should not be surfaced' }]
+  });
+  assert.equal(parsed.refused, true);
+  assert.equal(parsed.text, '');
+}
+
+// max_tokens marks the answer as truncated rather than failing it.
+{
+  const parsed = R2AIApiProviders.parseResponse('anthropic', {
+    stop_reason: 'max_tokens',
+    content: [{ type: 'text', text: 'cut off here' }]
+  });
+  assert.equal(parsed.truncated, true);
+  assert.equal(parsed.refused, false);
+  assert.equal(parsed.text, 'cut off here');
+}
+
+// OpenAI choices path.
+{
+  const parsed = R2AIApiProviders.parseResponse('openai', {
+    choices: [{ finish_reason: 'stop', message: { role: 'assistant', content: 'OpenAI answer' } }]
+  });
+  assert.equal(parsed.text, 'OpenAI answer');
+  assert.equal(parsed.truncated, false);
+
+  const truncated = R2AIApiProviders.parseResponse('openai', {
+    choices: [{ finish_reason: 'length', message: { content: 'partial' } }]
+  });
+  assert.equal(truncated.truncated, true);
+}
+
+// Gemini candidates path, joining multiple parts.
+{
+  const parsed = R2AIApiProviders.parseResponse('google', {
+    candidates: [{
+      finishReason: 'STOP',
+      content: { parts: [{ text: 'Gemini ' }, { text: 'answer' }] }
+    }]
+  });
+  assert.equal(parsed.text, 'Gemini answer');
+  assert.equal(parsed.truncated, false);
+
+  const blocked = R2AIApiProviders.parseResponse('google', {
+    candidates: [{ finishReason: 'SAFETY', content: { parts: [] } }]
+  });
+  assert.equal(blocked.refused, true);
+}
+
+// Malformed / empty payloads degrade to empty text rather than throwing.
+{
+  for (const provider of ['anthropic', 'openai', 'google']) {
+    const parsed = R2AIApiProviders.parseResponse(provider, {});
+    assert.equal(parsed.text, '', `${provider} empty payload yields empty text`);
+  }
+}
+
+// =====================
+// Error mapping
+// =====================
+
+// 429 surfaces the provider message and is marked retryable.
+{
+  const mapped = R2AIApiProviders.mapError('anthropic', 429, {
+    type: 'error',
+    error: { type: 'rate_limit_error', message: 'Number of requests has exceeded your rate limit.' }
+  });
+  assert.equal(mapped.retryable, true, '429 must be retryable');
+  assert.equal(mapped.status, 429);
+  assert.equal(mapped.type, 'rate_limit_error');
+  assert.equal(mapped.message, 'Number of requests has exceeded your rate limit.');
+}
+
+// 500 and 529 are retryable; 401 and 400 are not.
+{
+  assert.equal(R2AIApiProviders.mapError('anthropic', 500, {}).retryable, true);
+  assert.equal(R2AIApiProviders.mapError('anthropic', 529, {}).retryable, true);
+  assert.equal(R2AIApiProviders.mapError('anthropic', 401, {}).retryable, false);
+  assert.equal(R2AIApiProviders.mapError('openai', 400, {}).retryable, false);
+}
+
+// An auth failure keeps the provider's own wording.
+{
+  const mapped = R2AIApiProviders.mapError('openai', 401, {
+    error: { message: 'Incorrect API key provided.', type: 'invalid_request_error' }
+  });
+  assert.equal(mapped.message, 'Incorrect API key provided.');
+  assert.equal(mapped.retryable, false);
+}
+
+// Gemini nests its message the same way.
+{
+  const mapped = R2AIApiProviders.mapError('google', 429, {
+    error: { code: 429, message: 'Resource has been exhausted.', status: 'RESOURCE_EXHAUSTED' }
+  });
+  assert.equal(mapped.message, 'Resource has been exhausted.');
+  assert.equal(mapped.retryable, true);
+}
+
+// A body-less error still produces a usable message.
+{
+  const mapped = R2AIApiProviders.mapError('anthropic', 502, null);
+  assert.match(mapped.message, /Anthropic Claude request failed/);
+  assert.equal(mapped.retryable, true);
+}
+
+// =====================
+// OpenAI max_tokens fallback detection
+// =====================
+{
+  const detects = R2AIApiProviders.isMaxTokensParamError('openai', 400, {
+    error: {
+      message: "Unsupported parameter: 'max_completion_tokens' is not supported with this model.",
+      param: 'max_completion_tokens'
+    }
+  });
+  assert.equal(detects, true);
+
+  assert.equal(R2AIApiProviders.isMaxTokensParamError('openai', 400, { error: { message: 'bad request' } }), false);
+  assert.equal(R2AIApiProviders.isMaxTokensParamError('openai', 429, { error: { param: 'max_completion_tokens' } }), false);
+  assert.equal(R2AIApiProviders.isMaxTokensParamError('anthropic', 400, { error: { param: 'max_completion_tokens' } }), false);
+}
+
+console.log('Direct API provider unit tests passed!');

--- a/tests/backgroundBatchResumption.test.mjs
+++ b/tests/backgroundBatchResumption.test.mjs
@@ -145,6 +145,8 @@ function createContext() {
 
 async function loadServiceWorker(context) {
   const source = await readFile(new URL('../src/service_worker.js', import.meta.url), 'utf8');
+  const parserSource = await readFile(new URL('../src/redditParser.js', import.meta.url), 'utf8');
+  vm.runInNewContext(parserSource, context, { filename: 'redditParser.js' });
   vm.runInNewContext(source, context, { filename: 'service_worker.js' });
   return context.R2AIServiceWorkerTest;
 }

--- a/tests/backgroundScrapeHandoff.test.mjs
+++ b/tests/backgroundScrapeHandoff.test.mjs
@@ -1,0 +1,243 @@
+// Covers the MV3 lifetime handling for single-thread scrapes: the request/ack +
+// scrapeComplete protocol, scraping-state persistence into storage.session, and
+// the ready-gate that keeps the activeBatch auto-resume from racing messages.
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import vm from 'node:vm';
+
+const REDDIT_URL = 'https://www.reddit.com/r/test/comments/1/a';
+
+function createContext({ seed = {}, ackResponse = { started: true } } = {}) {
+  const storage = {
+    local: { ...(seed.local || {}) },
+    session: { ...(seed.session || {}) },
+    sync: { ...(seed.sync || {}) }
+  };
+
+  const createStorageArea = (areaName) => ({
+    get(keys, callback) {
+      const res = {};
+      if (typeof keys === 'string') {
+        res[keys] = storage[areaName][keys];
+      } else if (Array.isArray(keys)) {
+        keys.forEach(k => { res[k] = storage[areaName][k]; });
+      } else if (keys && typeof keys === 'object') {
+        Object.keys(keys).forEach(k => {
+          res[k] = storage[areaName][k] !== undefined ? storage[areaName][k] : keys[k];
+        });
+      } else {
+        Object.assign(res, storage[areaName]);
+      }
+      callback(res);
+    },
+    set(items, callback) {
+      Object.assign(storage[areaName], items);
+      callback?.();
+    },
+    remove(keys, callback) {
+      (Array.isArray(keys) ? keys : [keys]).forEach(k => { delete storage[areaName][k]; });
+      callback?.();
+    }
+  });
+
+  const tabMessages = [];
+  const createdTabs = [];
+  const injectedFiles = [];
+
+  return {
+    console: { log() {}, debug() {}, warn() {}, error() {} },
+    URL,
+    URLSearchParams,
+    Date,
+    crypto: { randomUUID: () => 'scrape-1' },
+    importScripts() {},
+    fetch: async () => { throw new Error('no network in test'); },
+    setTimeout(callback) { return globalThis.setTimeout(callback, 0); },
+    tabMessages,
+    createdTabs,
+    injectedFiles,
+    rawStorage: storage,
+    chrome: {
+      i18n: { getMessage: () => '' },
+      runtime: {
+        lastError: null,
+        onInstalled: { addListener() {} },
+        onStartup: { addListener() {} },
+        onMessage: { addListener() {} },
+        sendMessage(_message, callback) { callback?.({}); },
+        getURL(path) { return `chrome-extension://test/${path}`; }
+      },
+      tabs: {
+        create: async (options) => { createdTabs.push(options); return {}; },
+        query: async () => [{ id: 1, url: REDDIT_URL }],
+        sendMessage(_tabId, message, callback) {
+          tabMessages.push(message);
+          callback?.(message.action === 'scrapeReddit' ? ackResponse : {});
+        },
+        get(_tabId, callback) { callback({ id: 1, url: REDDIT_URL }); },
+        update: async () => ({})
+      },
+      windows: { update: async () => ({}) },
+      scripting: {
+        executeScript: async ({ files }) => { injectedFiles.push(...files); }
+      },
+      notifications: { create(_id, _options, callback) { callback?.(); } },
+      storage: {
+        local: createStorageArea('local'),
+        session: createStorageArea('session'),
+        sync: createStorageArea('sync')
+      }
+    },
+    R2AIPrompt: { countComments: () => 1 },
+    R2AIServiceWorkerTest: {}
+  };
+}
+
+async function loadServiceWorker(context) {
+  const parserSource = await readFile(new URL('../src/redditParser.js', import.meta.url), 'utf8');
+  const source = await readFile(new URL('../src/service_worker.js', import.meta.url), 'utf8');
+  vm.runInNewContext(parserSource, context, { filename: 'redditParser.js' });
+  vm.runInNewContext(source, context, { filename: 'service_worker.js' });
+  return context.R2AIServiceWorkerTest;
+}
+
+const scrapedData = {
+  post: { title: 'Hello', author: 'op', subreddit: 'test' },
+  comments: [{ id: 't1_a', parentId: 't3_1', author: 'user', text: 'hi', score: 1, replies: [] }]
+};
+
+// 1. The scrape request resolves as soon as the tab acknowledges, and the handoff
+//    context is persisted so a restarted worker can finish the job.
+{
+  const context = createContext();
+  const api = await loadServiceWorker(context);
+
+  const result = await api.handleScrapeRequest({ tabId: 1, filters: {} }, {});
+  assert.equal(result.started, true, 'request resolves on the start acknowledgement');
+  assert.ok(result.scrapeId, 'a scrape id is handed back');
+
+  const stored = context.rawStorage.session[api.SCRAPE_CONTEXT_KEY];
+  assert.ok(stored, 'scrape context is persisted to storage.session');
+  assert.equal(stored.scrapeId, result.scrapeId);
+  assert.equal(stored.tabId, 1);
+  assert.ok(stored.settings, 'settings snapshot travels with the context');
+
+  const request = context.tabMessages.find(message => message.action === 'scrapeReddit');
+  assert.equal(request.scrapeId, result.scrapeId, 'the scrape id is sent to the content script');
+
+  // State is still active: no result has arrived yet.
+  assert.equal(api.getScrapingState().isActive, true);
+  assert.ok(context.rawStorage.session[api.SCRAPING_STATE_KEY], 'scraping state is mirrored to storage.session');
+
+  // The pipeline resumes when the content script reports back.
+  await api.finishTabScrape(result.scrapeId, { data: scrapedData });
+
+  assert.equal(api.getScrapingState().isActive, false);
+  assert.equal(api.getScrapingState().percentage, 100);
+  assert.ok(context.rawStorage.local.redditPreviewData, 'preview data was saved');
+  assert.equal(context.rawStorage.local.scrapeHistory.length, 1, 'history entry was written');
+  assert.equal(context.createdTabs.length, 1);
+  assert.equal(context.createdTabs[0].url, 'chrome-extension://test/preview.html', 'the preview tab was opened');
+  assert.equal(context.rawStorage.session[api.SCRAPE_CONTEXT_KEY], undefined, 'context is cleared when done');
+}
+
+// 2. A completion for an unknown or superseded scrape is ignored rather than
+//    clobbering whatever is running now.
+{
+  const context = createContext();
+  const api = await loadServiceWorker(context);
+  await api.handleScrapeRequest({ tabId: 1, filters: {} }, {});
+
+  const outcome = await api.finishTabScrape('some-other-scrape', { data: scrapedData });
+  assert.equal(outcome.ignored, true);
+  assert.equal(api.getScrapingState().isActive, true, 'the live scrape is untouched');
+  assert.ok(context.rawStorage.session[api.SCRAPE_CONTEXT_KEY], 'context survives the stray message');
+}
+
+// 3. Cold start: a worker that never saw the request still restores the state and
+//    finishes the scrape from the persisted context.
+{
+  const priming = createContext();
+  const primingApi = await loadServiceWorker(priming);
+  await primingApi.handleScrapeRequest({ tabId: 1, filters: {} }, {});
+  const persistedSession = { ...priming.rawStorage.session };
+  const scrapeId = persistedSession[primingApi.SCRAPE_CONTEXT_KEY].scrapeId;
+
+  // A brand new worker generation, seeded only with what survived in session storage.
+  const context = createContext({ seed: { session: persistedSession } });
+  const api = await loadServiceWorker(context);
+  await api.ready;
+
+  assert.equal(api.getScrapingState().isActive, true, 'restored state reports the scrape as running');
+
+  await api.finishTabScrape(scrapeId, { data: scrapedData });
+  assert.ok(context.rawStorage.local.redditPreviewData, 'the restarted worker completed the handoff');
+  assert.equal(api.getScrapingState().isActive, false);
+  assert.equal(context.rawStorage.session[api.SCRAPE_CONTEXT_KEY], undefined);
+}
+
+// 4. A persisted state whose handoff context is gone must not wedge isActive, or the
+//    batch auto-resume below it would never run again.
+{
+  const context = createContext({
+    seed: { session: { redditScrapingState: { isActive: true, message: 'Collecting...', percentage: 20 } } }
+  });
+  const api = await loadServiceWorker(context);
+  await api.ready;
+
+  assert.equal(api.getScrapingState().isActive, false, 'a contextless active flag is dropped');
+  assert.equal(api.getScrapingState().message, 'Collecting...', 'the rest of the state is still restored');
+}
+
+// 5. A scrape reported as failed surfaces the error and releases the context.
+{
+  const context = createContext();
+  const api = await loadServiceWorker(context);
+  const { scrapeId } = await api.handleScrapeRequest({ tabId: 1, filters: {} }, {});
+
+  await assert.rejects(() => api.finishTabScrape(scrapeId, { error: 'Reddit blocked the request' }), /Reddit blocked the request/);
+  assert.equal(api.getScrapingState().isActive, false);
+  assert.match(api.getScrapingState().error, /Reddit blocked the request/);
+  assert.equal(context.rawStorage.session[api.SCRAPE_CONTEXT_KEY], undefined);
+}
+
+// 6. Stopping awaits the activeBatch removal instead of firing and forgetting, and
+//    also drops the single-scrape context.
+{
+  const context = createContext();
+  const api = await loadServiceWorker(context);
+  await api.handleScrapeRequest({ tabId: 1, filters: {} }, {});
+  context.rawStorage.local.activeBatch = { urls: [REDDIT_URL], currentIndex: 0 };
+
+  await api.stopActiveScrape();
+
+  assert.equal(context.rawStorage.local.activeBatch, undefined, 'activeBatch is gone once stop resolves');
+  assert.equal(context.rawStorage.session[api.SCRAPE_CONTEXT_KEY], undefined, 'scrape context is gone too');
+}
+
+// 7. Messages are answered only after init has settled, so no handler can observe a
+//    half-restored worker.
+{
+  const context = createContext();
+  const api = await loadServiceWorker(context);
+
+  const state = await new Promise(resolve => {
+    api.handleRuntimeMessage({ action: 'getScrapingState' }, {}, resolve);
+  });
+  assert.equal(state.isActive, false);
+  assert.equal(typeof api.ready.then, 'function', 'init exposes a promise for the message gate');
+}
+
+// 8. A stale content script that still replies with the payload instead of an
+//    acknowledgement is handled rather than reported as a protocol error.
+{
+  const context = createContext({ ackResponse: { data: scrapedData } });
+  const api = await loadServiceWorker(context);
+
+  const result = await api.handleScrapeRequest({ tabId: 1, filters: {} }, {});
+  assert.equal(result.started, true);
+  await new Promise(resolve => globalThis.setTimeout(resolve, 10));
+  assert.ok(context.rawStorage.local.redditPreviewData, 'legacy inline payload still completes the pipeline');
+}
+
+console.log('Background scrape handoff unit tests passed!');

--- a/tests/backgroundScraperReplies.test.mjs
+++ b/tests/backgroundScraperReplies.test.mjs
@@ -118,6 +118,8 @@ function createContext() {
 async function loadServiceWorker(customContext) {
   const context = customContext || createContext();
   const source = await readFile(new URL('../src/service_worker.js', import.meta.url), 'utf8');
+  const parserSource = await readFile(new URL('../src/redditParser.js', import.meta.url), 'utf8');
+  vm.runInNewContext(parserSource, context, { filename: 'redditParser.js' });
   vm.runInNewContext(source, context, { filename: 'service_worker.js' });
   return context.R2AIServiceWorkerTest;
 }
@@ -185,6 +187,21 @@ const api = await loadServiceWorker();
   assert.equal(filtered.length, 1);
   assert.equal(filtered[0].id, 't1_good_child');
   assert.equal(filtered[0].text, 'High score child');
+}
+
+// Bot filtering must catch real bots without eating human names ending in "bot".
+{
+  const authors = ['AutoModerator', 'sneakpeekbot', 'some_bot', 'some-bot', 'Talbot', 'Abbot', 'Sabotage', 'human'];
+  const filtered = api.applyBackgroundFilters(
+    authors.map((author, i) => ({ id: `t1_${i}`, parentId: 't3_thread', author, text: 'hi', score: 5, replies: [] })),
+    { hideBots: true },
+    {}
+  );
+  assert.deepEqual(
+    filtered.map(comment => comment.author),
+    ['Talbot', 'Abbot', 'Sabotage', 'human'],
+    'only known bots and word-boundary "bot" suffixes are removed'
+  );
 }
 
 {

--- a/tests/backgroundSelectorSync.test.mjs
+++ b/tests/backgroundSelectorSync.test.mjs
@@ -68,6 +68,8 @@ function createContext() {
 
 async function loadServiceWorker(context) {
   const source = await readFile(new URL('../src/service_worker.js', import.meta.url), 'utf8');
+  const parserSource = await readFile(new URL('../src/redditParser.js', import.meta.url), 'utf8');
+  vm.runInNewContext(parserSource, context, { filename: 'redditParser.js' });
   vm.runInNewContext(source, context, { filename: 'service_worker.js' });
   return context.R2AIServiceWorkerTest;
 }
@@ -84,10 +86,46 @@ async function loadServiceWorker(context) {
   await api.syncSelectors();
   assert.ok(context.getFetchCalled());
   assert.equal(context.getFetchUrl(), 'https://raw.githubusercontent.com/KhazP/Reddit-to-AI/main/selectors.json');
-  assert.deepEqual(context.getLocalStore().get('syncedSelectors'), {
-    gemini: { inputSelector: '.custom-gemini-selector' }
-  });
+  // Sanitized objects are created inside the vm realm, so compare structurally.
+  assert.equal(
+    JSON.stringify(context.getLocalStore().get('syncedSelectors')),
+    JSON.stringify({ gemini: { inputSelector: '.custom-gemini-selector' } })
+  );
   assert.ok(context.getLocalStore().get('lastSelectorSyncTime') > 0);
+}
+
+// Validation: unknown platforms, bad types and metadata keys are rejected
+{
+  const context = createContext();
+  const api = await loadServiceWorker(context);
+  const clean = api.sanitizeSyncedSelectors({
+    version: 1,
+    gemini: { inputSelector: '.g', isContentEditable: true },
+    chatgpt: { inputSelector: 42, isContentEditable: 'yes' },
+    claude: 'div.claude-input',
+    evilPlatform: { inputSelector: '.nope' },
+    groq: { inputSelector: '   ' },
+    deepseek: ['not', 'an', 'object']
+  });
+  assert.equal(
+    JSON.stringify(clean),
+    JSON.stringify({
+      gemini: { inputSelector: '.g', isContentEditable: true },
+      claude: 'div.claude-input'
+    })
+  );
+  assert.equal(api.sanitizeSyncedSelectors({ version: 1 }), null);
+  assert.equal(api.sanitizeSyncedSelectors(['a']), null);
+  assert.equal(api.sanitizeSyncedSelectors(null), null);
+}
+
+// Invalid remote payload is not stored
+{
+  const context = createContext();
+  context.setMockFetchResponse({ notAPlatform: { inputSelector: '.x' } });
+  const api = await loadServiceWorker(context);
+  await api.syncSelectors();
+  assert.equal(context.getLocalStore().get('syncedSelectors'), undefined);
 }
 
 // Test error path sync

--- a/tests/bpeTokenizer.test.mjs
+++ b/tests/bpeTokenizer.test.mjs
@@ -1,10 +1,15 @@
 import assert from 'node:assert/strict';
 import '../src/cl100k_base.js';
 
-assert.ok(globalThis.R2ATiktokenPromise, 'R2ATiktokenPromise is present');
-await globalThis.R2ATiktokenPromise;
+assert.equal(typeof globalThis.R2ATiktokenEnsure, 'function', 'R2ATiktokenEnsure is exposed');
+assert.equal(globalThis.R2ATiktoken, undefined, 'tokenizer is not loaded until it is requested');
 
-assert.ok(globalThis.R2ATiktoken, 'R2ATiktoken is instantiated after promise resolves');
+await globalThis.R2ATiktokenEnsure();
+
+assert.ok(globalThis.R2ATiktoken, 'R2ATiktoken is instantiated after the lazy load resolves');
+
+// A second call reuses the already-loaded instance.
+assert.equal(await globalThis.R2ATiktokenEnsure(), globalThis.R2ATiktoken, 'ensure is idempotent');
 assert.ok(globalThis.Tiktoken, 'Tiktoken class is defined');
 
 // Verify basic encoding and decoding

--- a/tests/directApiKeySafety.test.mjs
+++ b/tests/directApiKeySafety.test.mjs
@@ -1,0 +1,137 @@
+// Guards the security boundary around Direct API keys:
+//  - the settings export allowlist stays free of anything key-shaped,
+//  - exportSettings reads chrome.storage.sync, while keys live only in local,
+//  - importSettings cannot write a key back in from a crafted file,
+//  - no source file logs a key.
+import assert from 'node:assert/strict';
+import { readFile, readdir } from 'node:fs/promises';
+
+const optionsSource = await readFile(new URL('../src/options.js', import.meta.url), 'utf8');
+
+// 1. The portable settings allowlist must not contain any key-like field. Only keys
+//    named here can ever be exported, so this is the load-bearing assertion.
+const allowlistMatch = optionsSource.match(/const PORTABLE_SETTING_TYPES = \{([\s\S]*?)\};/);
+assert.ok(allowlistMatch, 'PORTABLE_SETTING_TYPES must exist in options.js');
+const allowlistKeys = [...allowlistMatch[1].matchAll(/^\s*([A-Za-z0-9_]+)\s*:/gm)].map(m => m[1]);
+assert.ok(allowlistKeys.length > 0, 'the allowlist should not be empty');
+
+const forbiddenPattern = /(apikey|api_key|secret|token|credential|password|bearer|directapi)/i;
+for (const key of allowlistKeys) {
+  assert.ok(
+    !forbiddenPattern.test(key),
+    `settings export allowlist must not contain a credential-like key: ${key}`
+  );
+}
+assert.ok(!allowlistKeys.includes('directApiConfig'), 'directApiConfig must never be exportable');
+
+// 2. exportSettings must read from chrome.storage.sync only. API keys are written to
+//    chrome.storage.local, so a sync-scoped export cannot reach them even by mistake.
+const exportBody = optionsSource.match(/function exportSettings\(\)\s*\{([\s\S]*?)\n    \}/);
+assert.ok(exportBody, 'exportSettings must exist');
+assert.match(exportBody[1], /chrome\.storage\.sync\.get/, 'exportSettings must read storage.sync');
+assert.ok(
+  !/chrome\.storage\.local/.test(exportBody[1]),
+  'exportSettings must not read chrome.storage.local, where API keys live'
+);
+assert.match(
+  exportBody[1],
+  /Object\.keys\(PORTABLE_SETTING_TYPES\)/,
+  'exportSettings must restrict itself to the allowlist'
+);
+
+// 3. Reproduce importSettings' filter: an import file carrying a key is dropped,
+//    because unknown keys are not in the allowlist.
+{
+  const portableTypes = Object.fromEntries(allowlistKeys.map(key => [key, 'string']));
+  const maliciousImport = {
+    selectedPreset: 'summarize',
+    directApiConfig: { anthropic: { apiKey: 'sk-attacker' } },
+    apiKey: 'sk-attacker',
+    openaiToken: 'sk-attacker'
+  };
+  const accepted = {};
+  for (const [key, value] of Object.entries(maliciousImport)) {
+    if (!portableTypes[key]) continue;
+    accepted[key] = value;
+  }
+  assert.deepEqual(Object.keys(accepted), ['selectedPreset'], 'only allowlisted keys survive an import');
+  assert.ok(!('directApiConfig' in accepted));
+  assert.ok(!('apiKey' in accepted));
+  assert.ok(!JSON.stringify(accepted).includes('sk-attacker'));
+}
+
+// 4. Keys must be stored in chrome.storage.local, never in sync.
+{
+  // Comments are stripped first so the assertion tests code, not the prose that
+  // explains why the code is the way it is.
+  const stripComments = (source) => source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/^\s*\/\/.*$/gm, '');
+
+  const serviceWorkerSource = await readFile(new URL('../src/service_worker.js', import.meta.url), 'utf8');
+  assert.match(
+    serviceWorkerSource,
+    /getStorage\(chrome\.storage\.local, DIRECT_API_CONFIG_KEY\)/,
+    'the service worker must read the API config from storage.local'
+  );
+
+  for (const [name, source] of [
+    ['service_worker.js', stripComments(serviceWorkerSource)],
+    ['options.js', stripComments(optionsSource)]
+  ]) {
+    // Any sync-area call that names the API config, in either direction.
+    assert.ok(
+      !/storage\.sync\.(get|set)\([^)]*(directApiConfig|DIRECT_API_CONFIG_KEY)/.test(source),
+      `${name} must not use chrome.storage.sync for the API config`
+    );
+    assert.ok(
+      !/getStorage\(chrome\.storage\.sync,\s*(DIRECT_API_CONFIG_KEY|'directApiConfig')/.test(source),
+      `${name} must not read the API config from storage.sync`
+    );
+    assert.ok(
+      !/setStorage\(chrome\.storage\.sync,\s*\{\s*\[?(DIRECT_API_CONFIG_KEY|'directApiConfig')/.test(source),
+      `${name} must not write the API config to storage.sync`
+    );
+  }
+
+  // Positive control: the options page persists the config through storage.local.
+  assert.match(
+    stripComments(optionsSource),
+    /chrome\.storage\.local\.set\(\{\s*\[DIRECT_API_CONFIG_KEY\]/,
+    'the options page must save the API config to storage.local'
+  );
+}
+
+// 5. No source file may log a key or interpolate one into a message.
+{
+  const srcDir = new URL('../src/', import.meta.url);
+  const files = (await readdir(srcDir)).filter(name => name.endsWith('.js'));
+  const loggingPattern = /console\.(log|debug|warn|error|info)\([^)]*\b(apiKey|api_key|x-api-key)\b/i;
+  for (const file of files) {
+    const source = await readFile(new URL(file, srcDir), 'utf8');
+    assert.ok(!loggingPattern.test(source), `${file} must never log an API key`);
+  }
+}
+
+// 6. The provider module must place keys in headers only, never in a URL or body.
+{
+  const { R2AIApiProviders } = await import('../src/apiProviders.js').then(() => globalThis);
+  const sentinel = 'SENTINEL-KEY-VALUE';
+  for (const provider of R2AIApiProviders.PROVIDER_IDS) {
+    const request = R2AIApiProviders.buildRequest(provider, {
+      apiKey: sentinel,
+      promptText: 'hello'
+    });
+    assert.ok(!request.url.includes(sentinel), `${provider}: key must not appear in the URL`);
+    assert.ok(
+      !JSON.stringify(request.body).includes(sentinel),
+      `${provider}: key must not appear in the request body`
+    );
+    assert.ok(
+      JSON.stringify(request.headers).includes(sentinel),
+      `${provider}: key must be carried in a header`
+    );
+  }
+}
+
+console.log('Direct API key safety tests passed!');

--- a/tests/directApiServiceWorker.test.mjs
+++ b/tests/directApiServiceWorker.test.mjs
@@ -1,0 +1,379 @@
+// Exercises the service worker half of Direct API mode: the fetch orchestration,
+// the OpenAI max_tokens fallback, error propagation and the history write-back.
+// fetch is always a stub — these tests never touch a real provider endpoint.
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import vm from 'node:vm';
+
+function createContext({ fetchImpl, localSeed = {} } = {}) {
+  const syncStore = new Map();
+  const localStore = new Map(Object.entries(localSeed));
+  const fetchCalls = [];
+
+  const makeArea = (store) => ({
+    get(keys, callback) {
+      const result = {};
+      if (Array.isArray(keys)) {
+        keys.forEach(k => { if (store.has(k)) result[k] = store.get(k); });
+      } else if (typeof keys === 'string') {
+        if (store.has(keys)) result[keys] = store.get(keys);
+      } else {
+        Object.keys(keys).forEach(k => result[k] = store.has(k) ? store.get(k) : keys[k]);
+      }
+      callback(result);
+    },
+    set(items, callback) {
+      Object.entries(items).forEach(([k, v]) => store.set(k, v));
+      callback?.();
+    },
+    remove(keys, callback) {
+      (Array.isArray(keys) ? keys : [keys]).forEach(k => store.delete(k));
+      callback?.();
+    }
+  });
+
+  const context = {
+    console: { log() {}, error() {}, debug() {}, warn() {} },
+    Date,
+    URL,
+    URLSearchParams,
+    AbortController,
+    setTimeout,
+    clearTimeout,
+    setInterval,
+    clearInterval,
+    JSON,
+    Math,
+    Number,
+    Object,
+    Array,
+    Set,
+    Map,
+    Promise,
+    Error,
+    String,
+    Boolean,
+    importScripts() {},
+    async fetch(url, init) {
+      fetchCalls.push({ url, init });
+      return fetchImpl(url, init, fetchCalls.length);
+    },
+    chrome: {
+      i18n: { getMessage: () => '' },
+      runtime: {
+        onInstalled: { addListener() {} },
+        onStartup: { addListener() {} },
+        onMessage: { addListener() {} }
+      },
+      storage: {
+        sync: makeArea(syncStore),
+        local: makeArea(localStore),
+        session: makeArea(new Map())
+      },
+      scripting: {
+        async registerContentScripts() {},
+        async unregisterContentScripts() {}
+      }
+    },
+    getFetchCalls() { return fetchCalls; },
+    getLocalStore() { return localStore; },
+    R2AIServiceWorkerTest: {}
+  };
+  context.globalThis = context;
+  return context;
+}
+
+async function loadServiceWorker(context) {
+  const providersSource = await readFile(new URL('../src/apiProviders.js', import.meta.url), 'utf8');
+  const parserSource = await readFile(new URL('../src/redditParser.js', import.meta.url), 'utf8');
+  const source = await readFile(new URL('../src/service_worker.js', import.meta.url), 'utf8');
+  vm.runInNewContext(providersSource, context, { filename: 'apiProviders.js' });
+  vm.runInNewContext(parserSource, context, { filename: 'redditParser.js' });
+  vm.runInNewContext(source, context, { filename: 'service_worker.js' });
+  return context.R2AIServiceWorkerTest;
+}
+
+function jsonResponse(status, payload) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    async json() { return payload; }
+  };
+}
+
+// 1. Anthropic happy path: key read from storage.local, text blocks joined.
+{
+  const context = createContext({
+    localSeed: {
+      directApiConfig: { anthropic: { apiKey: 'sk-ant-stored', model: 'claude-sonnet-5' } }
+    },
+    fetchImpl: () => jsonResponse(200, {
+      stop_reason: 'end_turn',
+      content: [{ type: 'text', text: 'Hello ' }, { type: 'text', text: 'world' }]
+    })
+  });
+  const api = await loadServiceWorker(context);
+
+  const result = await api.callDirectApi('anthropic', 'Summarize this.');
+  assert.equal(result.text, 'Hello world');
+  assert.equal(result.model, 'claude-sonnet-5', 'stored model overrides the default');
+  assert.equal(result.refused, false);
+  assert.equal(result.truncated, false);
+
+  const [call] = context.getFetchCalls();
+  assert.equal(call.url, 'https://api.anthropic.com/v1/messages');
+  assert.equal(call.init.headers['x-api-key'], 'sk-ant-stored');
+  assert.equal(call.init.headers['anthropic-version'], '2023-06-01');
+  assert.equal(call.init.headers['anthropic-dangerous-direct-browser-access'], 'true');
+  assert.ok(call.init.signal, 'an AbortController signal must be attached');
+  const body = JSON.parse(call.init.body);
+  assert.equal(body.messages[0].content, 'Summarize this.');
+  assert.equal(body.max_tokens, 8192);
+}
+
+// 2. A missing key fails before any network call is attempted.
+{
+  const context = createContext({
+    fetchImpl: () => { throw new Error('fetch must not be called'); }
+  });
+  const api = await loadServiceWorker(context);
+  await assert.rejects(() => api.callDirectApi('anthropic', 'hi'), /No API key is configured/);
+  assert.equal(context.getFetchCalls().length, 0);
+}
+
+// 3. Anthropic refusal surfaces as refused rather than as text.
+{
+  const context = createContext({
+    localSeed: { directApiConfig: { anthropic: { apiKey: 'k' } } },
+    fetchImpl: () => jsonResponse(200, {
+      stop_reason: 'refusal',
+      content: [{ type: 'text', text: 'leaked' }]
+    })
+  });
+  const api = await loadServiceWorker(context);
+  const result = await api.callDirectApi('anthropic', 'hi');
+  assert.equal(result.refused, true);
+  assert.equal(result.text, '');
+}
+
+// 4. A 429 propagates the provider message and is flagged retryable.
+{
+  const context = createContext({
+    localSeed: { directApiConfig: { anthropic: { apiKey: 'k' } } },
+    fetchImpl: () => jsonResponse(429, {
+      type: 'error',
+      error: { type: 'rate_limit_error', message: 'Slow down.' }
+    })
+  });
+  const api = await loadServiceWorker(context);
+  await assert.rejects(
+    () => api.callDirectApi('anthropic', 'hi'),
+    (error) => {
+      assert.equal(error.message, 'Slow down.');
+      assert.equal(error.retryable, true);
+      assert.equal(error.status, 429);
+      return true;
+    }
+  );
+}
+
+// 5. A 401 is not retryable.
+{
+  const context = createContext({
+    localSeed: { directApiConfig: { openai: { apiKey: 'k' } } },
+    fetchImpl: () => jsonResponse(401, { error: { message: 'Bad key.' } })
+  });
+  const api = await loadServiceWorker(context);
+  await assert.rejects(
+    () => api.callDirectApi('openai', 'hi'),
+    (error) => {
+      assert.equal(error.retryable, false);
+      return true;
+    }
+  );
+}
+
+// 6. OpenAI retries once with the legacy max_tokens field, then succeeds.
+{
+  const context = createContext({
+    localSeed: { directApiConfig: { openai: { apiKey: 'sk-openai' } } },
+    fetchImpl: (url, init, callNumber) => {
+      if (callNumber === 1) {
+        return jsonResponse(400, {
+          error: {
+            message: "Unsupported parameter: 'max_completion_tokens'.",
+            param: 'max_completion_tokens'
+          }
+        });
+      }
+      return jsonResponse(200, {
+        choices: [{ finish_reason: 'stop', message: { content: 'Second try worked' } }]
+      });
+    }
+  });
+  const api = await loadServiceWorker(context);
+  const result = await api.callDirectApi('openai', 'hi');
+  assert.equal(result.text, 'Second try worked');
+
+  const calls = context.getFetchCalls();
+  assert.equal(calls.length, 2, 'exactly one retry');
+  const first = JSON.parse(calls[0].init.body);
+  const second = JSON.parse(calls[1].init.body);
+  assert.equal(first.max_completion_tokens, 8192);
+  assert.equal(first.max_tokens, undefined);
+  assert.equal(second.max_tokens, 8192);
+  assert.equal(second.max_completion_tokens, undefined);
+  assert.equal(calls[0].init.headers.authorization, 'Bearer sk-openai');
+}
+
+// 7. A plain 400 is NOT retried.
+{
+  const context = createContext({
+    localSeed: { directApiConfig: { openai: { apiKey: 'k' } } },
+    fetchImpl: () => jsonResponse(400, { error: { message: 'Context length exceeded.' } })
+  });
+  const api = await loadServiceWorker(context);
+  await assert.rejects(() => api.callDirectApi('openai', 'hi'), /Context length exceeded/);
+  assert.equal(context.getFetchCalls().length, 1, 'a non-parameter 400 must not be retried');
+}
+
+// 8. Gemini: key in header, model in path, candidate parts joined.
+{
+  const context = createContext({
+    localSeed: { directApiConfig: { google: { apiKey: 'goog-key', model: 'gemini-2.5-pro' } } },
+    fetchImpl: () => jsonResponse(200, {
+      candidates: [{ finishReason: 'STOP', content: { parts: [{ text: 'Gem' }, { text: 'ini' }] } }]
+    })
+  });
+  const api = await loadServiceWorker(context);
+  const result = await api.callDirectApi('google', 'hi');
+  assert.equal(result.text, 'Gemini');
+
+  const [call] = context.getFetchCalls();
+  assert.equal(
+    call.url,
+    'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-pro:generateContent'
+  );
+  assert.equal(call.init.headers['x-goog-api-key'], 'goog-key');
+  assert.ok(!call.url.includes('goog-key'), 'the key must never reach the URL');
+}
+
+// 9. A network failure is wrapped without echoing the request (which holds the key).
+{
+  const context = createContext({
+    localSeed: { directApiConfig: { anthropic: { apiKey: 'super-secret-key' } } },
+    fetchImpl: () => { throw new Error('Failed to fetch'); }
+  });
+  const api = await loadServiceWorker(context);
+  await assert.rejects(
+    () => api.callDirectApi('anthropic', 'hi'),
+    (error) => {
+      assert.match(error.message, /Could not reach the AI provider/);
+      assert.ok(!error.message.includes('super-secret-key'), 'errors must never leak the key');
+      return true;
+    }
+  );
+}
+
+// 10. getDirectApiStatus reports configuration without ever returning a key.
+{
+  const context = createContext({
+    localSeed: {
+      directApiConfig: {
+        anthropic: { apiKey: 'secret-anthropic-key' },
+        google: { apiKey: '   ' }
+      }
+    },
+    fetchImpl: () => jsonResponse(200, {})
+  });
+  const api = await loadServiceWorker(context);
+  const status = await api.getDirectApiStatus();
+
+  assert.equal(status.providers.anthropic.configured, true);
+  assert.equal(status.providers.openai.configured, false);
+  assert.equal(status.providers.google.configured, false, 'a whitespace-only key is not configured');
+  assert.equal(status.providers.anthropic.model, 'claude-opus-5', 'falls back to the default model');
+
+  const serialized = JSON.stringify(status);
+  assert.ok(!serialized.includes('secret-anthropic-key'), 'status must never carry the key to a page');
+  assert.ok(!/apiKey/i.test(serialized), 'status must not expose an apiKey field');
+}
+
+// 11. sendPromptViaApi writes the response onto the linked history entry.
+{
+  const context = createContext({
+    localSeed: {
+      directApiConfig: { anthropic: { apiKey: 'k' } },
+      scrapeHistory: [{ id: 'hist-1', post: { title: 'A thread' } }]
+    },
+    fetchImpl: () => jsonResponse(200, {
+      stop_reason: 'end_turn',
+      content: [{ type: 'text', text: 'The summary.' }]
+    })
+  });
+  const api = await loadServiceWorker(context);
+
+  const result = await api.sendPromptViaApi({
+    apiProvider: 'anthropic',
+    promptText: 'Summarize.',
+    historyId: 'hist-1'
+  });
+  assert.equal(result.success, true);
+  assert.equal(result.response.text, 'The summary.');
+
+  const history = context.getLocalStore().get('scrapeHistory');
+  const entry = history.find(item => item.id === 'hist-1');
+  assert.ok(entry.apiResponse, 'the history entry gains an apiResponse field');
+  assert.equal(entry.apiResponse.text, 'The summary.');
+  assert.equal(entry.apiResponse.provider, 'anthropic');
+  assert.equal(entry.apiResponse.model, 'claude-opus-5');
+  assert.ok(!JSON.stringify(entry).includes('"apiKey"'), 'history must never store a key');
+}
+
+// 12. With history saving off there is no historyId, and the send still succeeds.
+{
+  const context = createContext({
+    localSeed: { directApiConfig: { anthropic: { apiKey: 'k' } } },
+    fetchImpl: () => jsonResponse(200, {
+      stop_reason: 'end_turn',
+      content: [{ type: 'text', text: 'ok' }]
+    })
+  });
+  const api = await loadServiceWorker(context);
+  const result = await api.sendPromptViaApi({ apiProvider: 'anthropic', promptText: 'hi' });
+  assert.equal(result.success, true);
+  assert.equal(context.getLocalStore().get('scrapeHistory'), undefined);
+}
+
+// 13. testDirectApiKey uses the supplied key and a minimal token budget.
+{
+  const context = createContext({
+    fetchImpl: () => jsonResponse(200, {
+      stop_reason: 'end_turn',
+      content: [{ type: 'text', text: 'OK' }]
+    })
+  });
+  const api = await loadServiceWorker(context);
+  const result = await api.testDirectApiKey({
+    apiProvider: 'anthropic',
+    apiKey: 'typed-in-options',
+    model: 'claude-haiku-4-5'
+  });
+  assert.equal(result.success, true);
+  assert.equal(result.model, 'claude-haiku-4-5');
+
+  const [call] = context.getFetchCalls();
+  const body = JSON.parse(call.init.body);
+  assert.equal(body.max_tokens, 16, 'the test request stays tiny');
+  assert.equal(body.messages[0].content, 'Say OK');
+  assert.equal(call.init.headers['x-api-key'], 'typed-in-options');
+}
+
+// 14. An unknown provider is rejected.
+{
+  const context = createContext({ fetchImpl: () => jsonResponse(200, {}) });
+  const api = await loadServiceWorker(context);
+  await assert.rejects(() => api.callDirectApi('bogus', 'hi'), /Unknown direct API provider/);
+}
+
+console.log('Direct API service worker tests passed!');

--- a/tests/domFallback.test.mjs
+++ b/tests/domFallback.test.mjs
@@ -236,6 +236,8 @@ function createContext(document, fetchMock) {
   });
 
   const source = await readFile(new URL('../src/redditScraper.js', import.meta.url), 'utf8');
+  const parserSource = await readFile(new URL('../src/redditParser.js', import.meta.url), 'utf8');
+  vm.runInNewContext(parserSource, context, { filename: 'redditParser.js' });
   vm.runInNewContext(source, context, { filename: 'redditScraper.js' });
 
   const result = context.window.scrapeFromDOM(false);
@@ -297,6 +299,8 @@ function createContext(document, fetchMock) {
   });
 
   const source = await readFile(new URL('../src/redditScraper.js', import.meta.url), 'utf8');
+  const parserSource = await readFile(new URL('../src/redditParser.js', import.meta.url), 'utf8');
+  vm.runInNewContext(parserSource, context, { filename: 'redditParser.js' });
   vm.runInNewContext(source, context, { filename: 'redditScraper.js' });
 
   // Simulate applying settings (e.g. setting maxDepth)

--- a/tests/firefoxManifest.test.mjs
+++ b/tests/firefoxManifest.test.mjs
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { BACKGROUND_LIBS, GECKO_ID, GECKO_MIN_VERSION, toFirefoxManifest } from '../scripts/firefox-manifest.mjs';
+
+const chromeManifest = JSON.parse(await readFile(new URL('../src/manifest.json', import.meta.url), 'utf8'));
+const firefox = toFirefoxManifest(chromeManifest);
+
+// --- background: event page, not a service worker -------------------------------
+assert.ok(!('service_worker' in (firefox.background || {})), 'Firefox background must not declare a service worker');
+assert.deepEqual(
+  firefox.background.scripts,
+  [...BACKGROUND_LIBS, 'service_worker.js'],
+  'shared libraries must load before service_worker.js, in importScripts order'
+);
+assert.ok(!firefox.background.type, 'background scripts are classic scripts sharing one global scope, not modules');
+
+// The Firefox script list stands in for the importScripts call, so the two must not
+// drift apart. Parse the argument list straight out of the source.
+const workerSource = await readFile(new URL('../src/service_worker.js', import.meta.url), 'utf8');
+const importCall = workerSource.match(/importScripts\(([^)]*)\)/);
+assert.ok(importCall, 'service_worker.js must still call importScripts for Chrome');
+const importedFiles = [...importCall[1].matchAll(/'([^']+)'/g)].map(match => match[1]);
+assert.deepEqual(importedFiles, BACKGROUND_LIBS, 'BACKGROUND_LIBS must match the importScripts argument order');
+
+// Firefox background pages have no importScripts, so the call must be guarded.
+assert.match(
+  workerSource,
+  /typeof importScripts === 'function'/,
+  'the importScripts call must be guarded so Firefox event pages can load the file'
+);
+
+// --- gecko settings --------------------------------------------------------------
+assert.equal(firefox.browser_specific_settings.gecko.id, GECKO_ID, 'gecko id is required for installing/signing');
+assert.equal(firefox.browser_specific_settings.gecko.strict_min_version, GECKO_MIN_VERSION);
+assert.match(GECKO_MIN_VERSION, /^\d+\.\d+$/, 'strict_min_version must be a Gecko version string');
+
+// --- options page ----------------------------------------------------------------
+// options_page is Chrome-only; without options_ui, runtime.openOptionsPage() is a no-op.
+assert.ok(!('options_page' in firefox), 'options_page must be converted for Firefox');
+assert.equal(firefox.options_ui.page, chromeManifest.options_page);
+assert.equal(firefox.options_ui.open_in_tab, true);
+
+// --- web accessible resources ----------------------------------------------------
+assert.ok(chromeManifest.web_accessible_resources.some(entry => entry.use_dynamic_url), 'Chrome manifest still sets use_dynamic_url');
+for (const [index, entry] of firefox.web_accessible_resources.entries()) {
+  assert.ok(!('use_dynamic_url' in entry), 'use_dynamic_url is Chrome-only and must be stripped');
+  assert.deepEqual(entry.resources, chromeManifest.web_accessible_resources[index].resources, 'resources must be unchanged');
+  assert.deepEqual(entry.matches, chromeManifest.web_accessible_resources[index].matches, 'matches must be unchanged');
+}
+
+// --- everything else is carried over verbatim ------------------------------------
+for (const key of ['manifest_version', 'version', 'default_locale', 'permissions', 'host_permissions', 'content_scripts', 'action', 'commands', 'icons']) {
+  assert.deepEqual(firefox[key], chromeManifest[key], `${key} must be identical across browsers`);
+}
+
+// The transform must not mutate its input.
+const untouched = JSON.parse(await readFile(new URL('../src/manifest.json', import.meta.url), 'utf8'));
+assert.deepEqual(chromeManifest, untouched, 'toFirefoxManifest must not mutate the Chrome manifest');
+
+assert.throws(() => toFirefoxManifest({ ...chromeManifest, background: {} }), /service_worker/, 'a missing service worker must fail loudly');

--- a/tests/optionsHistoryStatus.test.mjs
+++ b/tests/optionsHistoryStatus.test.mjs
@@ -30,3 +30,22 @@ for (const copy of [
 assert.match(options, /dropdown\.disabled = true/, 'resend dropdown is disabled while request is in flight');
 assert.match(options, /dropdown\.selectedIndex = 0/, 'resend dropdown resets after completion');
 assert.match(options, /button\.disabled = true/, 'clicked history action buttons are disabled while in flight');
+
+// Settings import hardening: allowlist + type validation, and a full page reload
+// instead of re-running initializeOptions() (which would double-bind listeners).
+assert.match(options, /PORTABLE_SETTING_TYPES\s*=\s*\{/, 'import/export share an explicit settings allowlist');
+assert.match(options, /function matchesExpectedType/, 'imported values are type-checked');
+assert.match(options, /Imported \$\{importedCount\} setting/, 'import reports how many keys were applied');
+assert.match(options, /skipped \$\{skippedCount\} unrecognized/, 'import reports how many keys were skipped');
+assert.match(options, /location\.reload\(\)/, 'options page reloads after import instead of re-initializing');
+
+{
+  const importBody = options.slice(options.indexOf('function importSettings('), options.indexOf('function showPendingImportStatus'));
+  assert.ok(!importBody.includes('initializeOptions()'), 'importSettings must not re-run initializeOptions (double-binds listeners)');
+  assert.ok(!/chrome\.storage\.sync\.set\(settings/.test(importBody), 'importSettings must not write the raw parsed payload');
+}
+
+// preview.js must escape scraped comment ids before interpolating them into HTML.
+const preview = await readFile(new URL('../src/preview.js', import.meta.url), 'utf8');
+assert.ok(!/data-(comment-)?id="\$\{comment\.id\}"/.test(preview), 'comment.id must not be interpolated raw into markup');
+assert.match(preview, /const commentId = escapeHtml\(/, 'comment ids are escaped through escapeHtml');

--- a/tests/packageExtension.test.mjs
+++ b/tests/packageExtension.test.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { readFile, stat } from 'node:fs/promises';
 import { join } from 'node:path';
 import { collectFiles, outDir, packageExtension, root, verifyZip } from '../scripts/package-extension.mjs';
+import { toFirefoxManifest } from '../scripts/firefox-manifest.mjs';
 
 const script = await readFile(new URL('../scripts/package-extension.mjs', import.meta.url), 'utf8');
 const manifest = JSON.parse(await readFile(new URL('../src/manifest.json', import.meta.url), 'utf8'));
@@ -34,3 +35,21 @@ for (const forbidden of ['package.json', 'package-lock.json', 'tests/promptBuild
 }
 
 await stat(join(root, `Reddit-to-AI-v${manifest.version}-upload.zip`));
+
+// --- Firefox artifact ------------------------------------------------------------
+const firefoxStaged = await collectFiles(result.firefoxOutDir);
+const firefoxZipFiles = await verifyZip(result.firefoxOutDir, result.firefoxZipPath);
+assert.deepEqual(firefoxZipFiles, firefoxStaged, 'Firefox zip must contain exactly the staged files');
+assert.deepEqual(firefoxStaged, stagedFiles, 'Firefox payload must ship the same file list as Chrome');
+
+const stagedFirefoxManifest = JSON.parse(await readFile(join(result.firefoxOutDir, 'manifest.json'), 'utf8'));
+assert.deepEqual(
+  stagedFirefoxManifest,
+  toFirefoxManifest(manifest),
+  'staged Firefox manifest must be the transform of the Chrome manifest'
+);
+
+const stagedChromeManifest = JSON.parse(await readFile(join(outDir, 'manifest.json'), 'utf8'));
+assert.deepEqual(stagedChromeManifest, manifest, 'the Chrome payload must ship src/manifest.json untouched');
+
+await stat(join(root, `Reddit-to-AI-v${manifest.version}-firefox.zip`));

--- a/tests/popupAccessibility.test.mjs
+++ b/tests/popupAccessibility.test.mjs
@@ -1,0 +1,88 @@
+// Covers the popup papercuts and accessibility fixes: no window.prompt() in the
+// action popup, keyboard-navigable tabs, non-tabbable collapsed regions, a native
+// min-score select, and a history resend that does not rewrite the user's default
+// AI provider.
+import assert from 'node:assert/strict';
+import { readdir, readFile } from 'node:fs/promises';
+
+const popupJs = await readFile(new URL('../src/popup.js', import.meta.url), 'utf8');
+const popupHtml = await readFile(new URL('../src/popup.html', import.meta.url), 'utf8');
+const popupCss = await readFile(new URL('../src/popup.css', import.meta.url), 'utf8');
+const worker = await readFile(new URL('../src/service_worker.js', import.meta.url), 'utf8');
+
+// 1. window.prompt() is blocked in action popups; the preset name is collected inline.
+{
+  assert.doesNotMatch(popupJs, /(^|[^.\w])prompt\(['"]Preset name/, 'window.prompt is gone');
+  assert.match(popupHtml, /id="presetNameRow"/, 'an inline preset-name row exists');
+  assert.match(popupHtml, /id="presetNameInput"/);
+  assert.match(popupHtml, /id="presetNameConfirmBtn"/);
+  assert.match(popupHtml, /id="presetNameCancelBtn"/);
+  assert.match(popupJs, /function commitPresetName\(\)/, 'confirm path is wired');
+  assert.match(popupJs, /function closePresetNameRow\(\)/, 'cancel path is wired');
+  assert.match(popupJs, /e\.key === 'Escape'/, 'Escape closes the inline row');
+  assert.match(popupCss, /\.preset-name-row/, 'the row is styled');
+}
+
+// 2. The preset-name strings exist in every locale.
+{
+  const localesDir = new URL('../src/_locales/', import.meta.url);
+  const locales = await readdir(localesDir);
+  const required = [
+    'popup_preset_name_label',
+    'popup_preset_name_placeholder',
+    'popup_preset_name_confirm',
+    'popup_preset_name_cancel',
+    'popup_preset_name_default'
+  ];
+  assert.equal(locales.length, 8, 'all eight locales are present');
+  for (const locale of locales) {
+    const messages = JSON.parse(await readFile(new URL(`${locale}/messages.json`, localesDir), 'utf8'));
+    for (const key of required) {
+      assert.ok(messages[key]?.message?.trim(), `${locale} defines ${key}`);
+    }
+  }
+}
+
+// 3. The tablist is keyboard navigable with a roving tabindex.
+{
+  assert.match(popupJs, /function activateTab\(btn/, 'tab activation is centralised');
+  for (const key of ['ArrowRight', 'ArrowLeft', 'ArrowDown', 'ArrowUp', 'Home', 'End']) {
+    assert.ok(popupJs.includes(`'${key}'`), `the tablist handles ${key}`);
+  }
+  assert.match(popupJs, /b\.tabIndex = selected \? 0 : -1/, 'roving tabindex is applied');
+}
+
+// 4. Collapsed regions are genuinely inaccessible, not just aria-hidden.
+{
+  assert.match(popupJs, /c\.hidden = true/, 'inactive tab panels get the hidden attribute');
+  assert.match(popupJs, /targetPane\.hidden = false/, 'the active panel is unhidden');
+  assert.match(popupHtml, /id="tabPaneFilters"[^>]*hidden>/, 'the initially inactive panel starts hidden');
+
+  // The advanced panel animates via grid-template-rows, so it uses inert instead
+  // of hidden, which would break the transition.
+  assert.match(popupJs, /advancedFilters\.inert = !expanded/, 'the advanced panel toggles inert');
+  assert.match(popupHtml, /id="advancedFilters"[^>]*inert>/, 'it starts inert while collapsed');
+  assert.match(popupCss, /grid-template-rows/, 'the collapse animation is still in place');
+}
+
+// 5. The min-score control is a native select, not a hand-rolled listbox.
+{
+  assert.match(popupHtml, /<select id="filterMinScore"/, 'min score is a native select');
+  assert.match(popupHtml, /aria-label="Minimum comment score"/, 'the select is labelled');
+  assert.doesNotMatch(popupHtml, /custom-select/, 'the custom dropdown markup is gone');
+  assert.doesNotMatch(popupJs, /custom-select/, 'the custom dropdown script is gone');
+  assert.doesNotMatch(popupCss, /custom-select/, 'the custom dropdown styles are gone');
+  assert.match(popupCss, /\.filter-select-native/, 'the native select keeps the pill styling');
+  assert.match(popupJs, /setMinScore\(saved, \{ persist: false \}\)/, 'restoring does not write back to storage');
+}
+
+// 6. Resending a history item must not overwrite the saved default provider.
+{
+  const resend = worker.slice(worker.indexOf('async function resendHistoryItem'), worker.indexOf('async function compareHistoryItems'));
+  assert.ok(resend.length > 0, 'resendHistoryItem was located');
+  assert.doesNotMatch(resend, /storage\.sync\.set/, 'the provider is no longer persisted');
+  assert.match(resend, /selectedLlmProvider: aiProvider \|\| settings\.selectedLlmProvider/, 'the override still travels in the payload');
+  assert.match(resend, /savePreviewData\(scrapeData, \{ \.\.\.mergedSettings/, 'the payload carries the merged settings');
+}
+
+console.log('Popup accessibility and papercut tests passed!');

--- a/tests/previewDirectApiUi.test.mjs
+++ b/tests/previewDirectApiUi.test.mjs
@@ -1,0 +1,99 @@
+// Contract tests for the preview page's Direct API panel. The important one is the
+// rendering path: the model response is derived from untrusted Reddit text and must
+// never be injected as markup.
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const previewRaw = await readFile(new URL('../src/preview.js', import.meta.url), 'utf8');
+// Comments are stripped so that prose explaining *why* innerHTML is avoided cannot
+// itself trip the assertions below.
+const preview = previewRaw
+  .replace(/\/\*[\s\S]*?\*\//g, '')
+  .replace(/^\s*\/\/.*$/gm, '');
+const html = await readFile(new URL('../src/preview.html', import.meta.url), 'utf8');
+const css = await readFile(new URL('../src/preview.css', import.meta.url), 'utf8');
+
+// --- Markup is wired up ---
+for (const id of [
+  'apiProviderSelect',
+  'sendApiBtn',
+  'apiNotConfigured',
+  'apiOpenOptionsBtn',
+  'apiLoading',
+  'apiElapsed',
+  'apiError',
+  'apiErrorMessage',
+  'apiRetryBtn',
+  'apiResult',
+  'apiResponseText',
+  'apiCopyBtn'
+]) {
+  assert.match(html, new RegExp(`id="${id}"`), `preview.html must define #${id}`);
+  assert.match(preview, new RegExp(`els\\.${id}\\b`), `preview.js must bind #${id}`);
+}
+
+// --- The response is rendered as text, never as HTML ---
+const renderBody = preview.match(/function renderApiResponse\(result\)\s*\{([\s\S]*?)\n\}/);
+assert.ok(renderBody, 'renderApiResponse must exist');
+assert.ok(
+  !/innerHTML/.test(renderBody[1]),
+  'renderApiResponse must never use innerHTML: the response is untrusted content'
+);
+assert.match(
+  renderBody[1],
+  /els\.apiResponseText\.textContent\s*=\s*result\.text/,
+  'the response body must be assigned with textContent'
+);
+
+// The error message is likewise provider-controlled text.
+const errorBody = preview.match(/function showApiError\(message, retryable\)\s*\{([\s\S]*?)\n\}/);
+assert.ok(errorBody, 'showApiError must exist');
+assert.ok(!/innerHTML/.test(errorBody[1]), 'showApiError must not use innerHTML');
+
+// The provider dropdown is built from DOM nodes, not an HTML string.
+const statusBody = preview.match(/function loadDirectApiStatus\(\)\s*\{([\s\S]*?)\n\}/);
+assert.ok(statusBody, 'loadDirectApiStatus must exist');
+assert.match(statusBody[1], /option\.textContent\s*=/, 'option labels must be set with textContent');
+assert.ok(
+  !/apiProviderSelect\.innerHTML\s*=\s*[`'"][^`'"]/.test(statusBody[1]),
+  'the provider select must not be populated from an HTML string'
+);
+
+// --- Whitespace is preserved by CSS rather than by markup ---
+assert.match(
+  css,
+  /\.api-response-text\s*\{[^}]*white-space:\s*pre-wrap/,
+  'the response panel must preserve whitespace with white-space: pre-wrap'
+);
+assert.match(
+  css,
+  /\.api-response-text\s*\{[^}]*overflow-y:\s*auto/,
+  'the response panel must scroll rather than grow without bound'
+);
+
+// --- Flow behaviour ---
+assert.match(preview, /action:\s*'sendPromptViaApi'/, 'preview must call the sendPromptViaApi action');
+assert.match(preview, /action:\s*'getDirectApiStatus'/, 'preview must query configured providers');
+assert.match(preview, /function updateApiAvailability\(\)/, 'send must be gated on a configured key');
+assert.match(preview, /chrome\.runtime\.openOptionsPage\(\)/, 'an unconfigured provider must link to options');
+assert.match(preview, /setInterval\(/, 'the loading state shows an elapsed-time counter');
+assert.match(preview, /clearInterval\(previewState\.apiTimer\)/, 'the elapsed timer must be cleared');
+assert.match(preview, /historyId:\s*previewState\.historyId/, 'the response is linked to its history entry');
+assert.match(preview, /els\.apiRetryBtn\?\.addEventListener\('click', sendPromptViaApi\)/, 'errors offer a retry');
+
+// A key saved on the options page must re-enable the button without a reload.
+assert.match(
+  preview,
+  /chrome\.storage\.onChanged\.addListener/,
+  'the preview page must refresh provider status when the API config changes'
+);
+assert.match(
+  preview,
+  /if \(previewState\.apiInFlight\) return;/,
+  'the refresh must not disturb an in-flight request'
+);
+
+// The preview page must never receive or handle a raw API key.
+assert.ok(!/apiKey/.test(preview), 'preview.js must never touch an API key');
+
+console.log('Preview Direct API UI tests passed!');

--- a/tests/promptBudgetTrim.test.mjs
+++ b/tests/promptBudgetTrim.test.mjs
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict';
+import '../src/promptBuilder.js';
+
+const { R2AIPrompt } = globalThis;
+
+const BALANCED_MAX_CHARS = R2AIPrompt.CONTEXT_PRESETS.balanced.maxChars;
+assert.equal(BALANCED_MAX_CHARS, 70000, 'balanced preset budget assumption');
+
+function makeThread(commentCount, textLength) {
+  const body = 'x'.repeat(textLength);
+  return {
+    post: {
+      title: 'Oversized thread',
+      subreddit: 'testing',
+      author: 'op',
+      url: 'https://www.reddit.com/r/testing/comments/big/oversized/',
+      content: 'Post body'
+    },
+    comments: Array.from({ length: commentCount }, (_, i) => ({
+      id: `t1_${i}`,
+      author: `user${i}`,
+      text: `${body} ${i}`,
+      score: commentCount - i,
+      replies: []
+    })),
+    metadata: { scrapedAt: '2026-04-27T00:00:00.000Z', commentCount }
+  };
+}
+
+const template = 'Please analyze the following Reddit thread.\n\n{content}';
+const options = { contextPreset: 'balanced', trimStrategy: 'top', mediaMode: 'ignore' };
+
+// Oversized thread: many small comments, well past both the count and char budgets.
+{
+  // Comments are long enough that the char budget binds before the 180-comment preset limit.
+  const big = makeThread(600, 900);
+  const untrimmed = R2AIPrompt.buildPromptText(big, template, {
+    ...options,
+    skipContextPreset: true,
+    skipBudgetTrim: true
+  });
+  assert.ok(untrimmed.length > BALANCED_MAX_CHARS, 'fixture must exceed the budget before trimming');
+
+  const prompt = R2AIPrompt.buildPromptText(big, template, options);
+  assert.ok(
+    prompt.length <= BALANCED_MAX_CHARS,
+    `trimmed prompt should fit the budget (got ${prompt.length})`
+  );
+  assert.ok(
+    prompt.length >= BALANCED_MAX_CHARS * 0.85,
+    `trimmed prompt should land within ~10-15% of the budget (got ${prompt.length})`
+  );
+}
+
+// Small threads are untouched by the budget trim.
+{
+  const small = makeThread(5, 100);
+  const withBudget = R2AIPrompt.buildPromptText(small, template, options);
+  const withoutBudget = R2AIPrompt.buildPromptText(small, template, { ...options, skipBudgetTrim: true });
+  assert.equal(withBudget, withoutBudget, 'small threads must not be trimmed');
+  assert.equal(
+    R2AIPrompt.countDataComments(
+      R2AIPrompt.trimCommentsToCharBudget(small, template, options, BALANCED_MAX_CHARS)
+    ),
+    5,
+    'trimCommentsToCharBudget is a no-op under budget'
+  );
+}
+
+// maxQuality (maxChars: 0) skips budget trimming entirely.
+{
+  const big = makeThread(400, 300);
+  const maxQuality = R2AIPrompt.buildPromptText(big, template, { ...options, contextPreset: 'maxQuality' });
+  assert.ok(maxQuality.length > BALANCED_MAX_CHARS, 'maxQuality preset does not enforce a char budget');
+}
+
+console.log('Prompt budget trim tests passed!');

--- a/tests/releaseManifest.test.mjs
+++ b/tests/releaseManifest.test.mjs
@@ -12,11 +12,16 @@ assert.equal(manifest.action?.default_popup, 'popup.html', 'popup page must be p
 assert.equal(manifest.options_page, 'options.html', 'options page must be packaged');
 assert.equal(manifest.background?.service_worker, 'service_worker.js', 'service worker must be packaged');
 
-for (const permission of ['activeTab', 'scripting', 'storage', 'notifications', 'tabs']) {
+for (const permission of ['activeTab', 'scripting', 'storage', 'notifications']) {
   assert.ok(manifest.permissions.includes(permission), `expected permission: ${permission}`);
 }
 
-const allowedPermissions = new Set(['activeTab', 'scripting', 'storage', 'notifications', 'tabs', 'unlimitedStorage']);
+// The broad `tabs` permission is deliberately not requested: every tab URL the
+// extension reads belongs either to a Reddit tab (covered by host_permissions)
+// or to the active tab at the moment the user invokes the action (activeTab).
+assert.ok(!manifest.permissions.includes('tabs'), 'the broad "tabs" permission must not be requested');
+
+const allowedPermissions = new Set(['activeTab', 'scripting', 'storage', 'notifications', 'unlimitedStorage', 'contextMenus']);
 for (const permission of manifest.permissions) {
   assert.ok(allowedPermissions.has(permission), `unexpected permission: ${permission}`);
 }
@@ -32,11 +37,27 @@ const allowedHosts = new Set([
   'https://claude.ai/*',
   'https://aistudio.google.com/*',
   'https://chat.deepseek.com/*',
-  'https://*.groq.com/*'
+  'https://*.groq.com/*',
+  // Direct API mode calls these three origins with fetch() from the service worker.
+  // They are API endpoints only: no content script is injected into them.
+  'https://api.anthropic.com/*',
+  'https://api.openai.com/*',
+  'https://generativelanguage.googleapis.com/*'
 ]);
 for (const host of manifest.host_permissions) {
   assert.ok(allowedHosts.has(host), `unexpected host permission: ${host}`);
 }
+
+// Keyboard shortcut must stay declared with a localized description.
+assert.ok(manifest.commands?.['scrape-current-thread'], 'scrape-current-thread command must be declared');
+assert.match(
+  manifest.commands['scrape-current-thread'].description || '',
+  /^__MSG_[a-zA-Z0-9_]+__$/,
+  'command description must be localized'
+);
+
+// The context menu needs the contextMenus permission to register its entries.
+assert.ok(manifest.permissions.includes('contextMenus'), 'contextMenus permission is required for the right-click entry');
 
 for (const icon of ['16', '48', '128']) {
   assert.ok(manifest.icons?.[icon], `manifest icon ${icon} is required`);

--- a/tests/scrapingStatePhases.test.mjs
+++ b/tests/scrapingStatePhases.test.mjs
@@ -1,0 +1,192 @@
+// Covers the structured scraping-state contract: the service worker publishes
+// machine-readable `phase` / `status` / `batch` fields, and the UI layers key off
+// those rather than pattern-matching localized message text.
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import vm from 'node:vm';
+
+const REDDIT_URL = 'https://www.reddit.com/r/test/comments/1/a';
+
+function createContext() {
+  const storage = { local: {}, session: {}, sync: {} };
+
+  const createStorageArea = (areaName) => ({
+    get(keys, callback) {
+      const res = {};
+      if (typeof keys === 'string') {
+        res[keys] = storage[areaName][keys];
+      } else if (Array.isArray(keys)) {
+        keys.forEach(k => { res[k] = storage[areaName][k]; });
+      } else if (keys && typeof keys === 'object') {
+        Object.keys(keys).forEach(k => {
+          res[k] = storage[areaName][k] !== undefined ? storage[areaName][k] : keys[k];
+        });
+      } else {
+        Object.assign(res, storage[areaName]);
+      }
+      callback(res);
+    },
+    set(items, callback) {
+      Object.assign(storage[areaName], items);
+      callback?.();
+    },
+    remove(keys, callback) {
+      (Array.isArray(keys) ? keys : [keys]).forEach(k => { delete storage[areaName][k]; });
+      callback?.();
+    }
+  });
+
+  return {
+    console: { log() {}, debug() {}, warn() {}, error() {} },
+    URL,
+    URLSearchParams,
+    Date,
+    crypto: { randomUUID: () => 'scrape-1' },
+    importScripts() {},
+    fetch: async () => { throw new Error('no network in test'); },
+    setTimeout(callback) { return globalThis.setTimeout(callback, 0); },
+    rawStorage: storage,
+    chrome: {
+      i18n: { getMessage: () => '' },
+      runtime: {
+        lastError: null,
+        onInstalled: { addListener() {} },
+        onStartup: { addListener() {} },
+        onMessage: { addListener() {} },
+        sendMessage(_message, callback) { callback?.({}); },
+        getURL(path) { return `chrome-extension://test/${path}`; }
+      },
+      tabs: {
+        create: async () => ({}),
+        query: async () => [{ id: 1, url: REDDIT_URL }],
+        sendMessage(_tabId, message, callback) {
+          callback?.(message.action === 'scrapeReddit' ? { started: true } : {});
+        },
+        get(_tabId, callback) { callback({ id: 1, url: REDDIT_URL }); },
+        update: async () => ({})
+      },
+      windows: { update: async () => ({}) },
+      scripting: { executeScript: async () => {} },
+      notifications: { create(_id, _options, callback) { callback?.(); } },
+      storage: {
+        local: createStorageArea('local'),
+        session: createStorageArea('session'),
+        sync: createStorageArea('sync')
+      }
+    },
+    R2AIPrompt: { countComments: () => 1 },
+    R2AIServiceWorkerTest: {}
+  };
+}
+
+async function loadServiceWorker(context) {
+  const parserSource = await readFile(new URL('../src/redditParser.js', import.meta.url), 'utf8');
+  const source = await readFile(new URL('../src/service_worker.js', import.meta.url), 'utf8');
+  vm.runInNewContext(parserSource, context, { filename: 'redditParser.js' });
+  vm.runInNewContext(source, context, { filename: 'service_worker.js' });
+  return context.R2AIServiceWorkerTest;
+}
+
+const scrapedData = {
+  post: { title: 'Hello', author: 'op', subreddit: 'test' },
+  comments: [{ id: 't1_a', parentId: 't3_1', author: 'user', text: 'hi', score: 1, replies: [] }]
+};
+
+// 1. A fresh worker starts idle with the structured fields present.
+{
+  const context = createContext();
+  const api = await loadServiceWorker(context);
+  const state = api.getScrapingState();
+  assert.equal(state.phase, 'idle');
+  assert.equal(state.status, 'idle');
+  assert.equal(state.batch, null);
+}
+
+// 2. A single-thread scrape walks prepare → fetch → build → complete, and the
+//    terminal state is marked complete without any English message sniffing.
+{
+  const context = createContext();
+  const api = await loadServiceWorker(context);
+
+  const result = await api.handleScrapeRequest({ tabId: 1, filters: {} }, {});
+  const running = api.getScrapingState();
+  assert.equal(running.status, 'running');
+  assert.ok(['prepare', 'fetch'].includes(running.phase), `unexpected running phase: ${running.phase}`);
+
+  await api.finishTabScrape(result.scrapeId, { data: scrapedData });
+
+  const done = api.getScrapingState();
+  assert.equal(done.isActive, false);
+  assert.equal(done.phase, 'complete');
+  assert.equal(done.status, 'complete');
+  assert.equal(done.batch, null);
+}
+
+// 3. Errors are reported structurally, not only as an "Error: ..." message string.
+{
+  const context = createContext();
+  const api = await loadServiceWorker(context);
+  const result = await api.handleScrapeRequest({ tabId: 1, filters: {} }, {});
+
+  await assert.rejects(() => api.finishTabScrape(result.scrapeId, { error: 'boom' }));
+
+  const state = api.getScrapingState();
+  assert.equal(state.phase, 'error');
+  assert.equal(state.status, 'error');
+  assert.equal(state.batch, null);
+  assert.ok(state.error);
+}
+
+// 4. A progressUpdate carrying a phase publishes its batch counter, and a later
+//    phase without one clears it so the panel badge cannot go stale.
+{
+  const context = createContext();
+  const api = await loadServiceWorker(context);
+
+  api.setScrapingState({ phase: 'load', status: 'running', batch: { current: 2, total: 7 } });
+  assert.deepEqual(api.getScrapingState().batch, { current: 2, total: 7 });
+
+  api.setScrapingState({ phase: 'filter', status: 'running', batch: null });
+  assert.equal(api.getScrapingState().batch, null, 'batch is cleared once the counting phase ends');
+}
+
+// 5. The content script tags its progress updates with a phase.
+{
+  const scraper = await readFile(new URL('../src/redditScraper.js', import.meta.url), 'utf8');
+  assert.match(scraper, /function sendProgress\(message, percentage, phase, batch\)/, 'sendProgress takes a phase');
+  assert.match(scraper, /action: 'progressUpdate', message, percentage, phase, batch/, 'the phase is transmitted');
+  for (const phase of ['fetch', 'parse', 'expand', 'load', 'filter']) {
+    assert.ok(scraper.includes(`'${phase}'`), `content script emits the ${phase} phase`);
+  }
+  assert.match(scraper, /'load', \{ current: processedBatches/, 'the batch loader reports a batch counter');
+  // The comment count the panel badge used to scrape out of the message text now
+  // has its own structured channel.
+  assert.match(scraper, /'expand', \{ count \}/, 'the expand phase reports its comment count');
+}
+
+// 5b. The panel renders both counter shapes off the structured field.
+{
+  const panel = await readFile(new URL('../src/floatingPanel.js', import.meta.url), 'utf8');
+  assert.match(panel, /Number\.isFinite\(batch\.current\) && Number\.isFinite\(batch\.total\)/, 'x-of-y counters render');
+  assert.match(panel, /Number\.isFinite\(batch\.count\)/, 'bare comment counts render');
+}
+
+// 6. The UI layers read the structured fields, keeping string matching as a
+//    clearly-labelled fallback only.
+{
+  const panel = await readFile(new URL('../src/floatingPanel.js', import.meta.url), 'utf8');
+  assert.match(panel, /PHASE_TO_TRACK/, 'panel maps backend phases onto its track');
+  assert.match(panel, /function resolvePhase\(data\)/, 'panel resolves the phase from state');
+  assert.match(panel, /function resolveBatchInfo\(data\)/, 'panel resolves batch info from state');
+  assert.match(panel, /data\.status === 'complete'/, 'auto-hide keys off status');
+  // The legacy helpers survive only as renamed fallbacks.
+  assert.match(panel, /function detectPhaseFromMessage\(message\)/);
+  assert.match(panel, /function extractBatchInfoFromMessage\(message\)/);
+  assert.doesNotMatch(panel, /updatePhaseUI\(detectPhase\(/, 'panel no longer drives the track from message text');
+
+  const popup = await readFile(new URL('../src/popup.js', import.meta.url), 'utf8');
+  assert.match(popup, /state\.status === 'complete'/, 'popup success toast keys off status');
+  assert.match(popup, /state\.phase === 'complete'/, 'popup falls back to phase before message text');
+}
+
+console.log('Scraping state phase tests passed successfully!');

--- a/tests/serviceWorkerCustomOrigins.test.mjs
+++ b/tests/serviceWorkerCustomOrigins.test.mjs
@@ -75,6 +75,8 @@ function createContext() {
 
 async function loadServiceWorker(context) {
   const source = await readFile(new URL('../src/service_worker.js', import.meta.url), 'utf8');
+  const parserSource = await readFile(new URL('../src/redditParser.js', import.meta.url), 'utf8');
+  vm.runInNewContext(parserSource, context, { filename: 'redditParser.js' });
   vm.runInNewContext(source, context, { filename: 'service_worker.js' });
   return context.R2AIServiceWorkerTest;
 }
@@ -95,8 +97,9 @@ async function loadServiceWorker(context) {
   assert.equal(await api.getAiUrl('deepseek'), 'https://chat.deepseek.com/');
   assert.equal(await api.getAiUrl('groq'), 'https://groq.com/');
 
-  // custom empty storage
-  assert.equal(await api.getAiUrl('custom'), 'http://localhost:3000/');
+  // custom provider without a configured origin must fail loudly instead of
+  // silently opening a hard-coded localhost URL
+  await assert.rejects(() => api.getAiUrl('custom'), /custom AI origin/i);
 
   // custom with storage match ending with /*
   context.getSyncStore().set('customOrigins', ['http://localhost:8080/*']);

--- a/tests/serviceWorkerStorageErrors.test.mjs
+++ b/tests/serviceWorkerStorageErrors.test.mjs
@@ -1,0 +1,104 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import vm from 'node:vm';
+
+function makeArea(store, { failOnSet = null } = {}) {
+  return {
+    store,
+    get(keys, callback) {
+      const result = {};
+      const list = Array.isArray(keys) ? keys : [keys];
+      list.forEach(k => { if (store.has(k)) result[k] = store.get(k); });
+      callback(result);
+    },
+    set(items, callback) {
+      if (failOnSet) {
+        context.chrome.runtime.lastError = { message: failOnSet };
+        callback();
+        context.chrome.runtime.lastError = null;
+        return;
+      }
+      Object.entries(items).forEach(([k, v]) => store.set(k, v));
+      callback();
+    },
+    remove(keys, callback) {
+      (Array.isArray(keys) ? keys : [keys]).forEach(k => store.delete(k));
+      callback();
+    }
+  };
+}
+
+let context;
+
+function createContext() {
+  const localStore = new Map();
+  const sessionStore = new Map();
+  context = {
+    console: { log() {}, debug() {}, warn() {}, error() {} },
+    Date,
+    URL,
+    URLSearchParams,
+    crypto: globalThis.crypto,
+    importScripts() {},
+    fetch: async () => { throw new Error('no network in test'); },
+    chrome: {
+      i18n: { getMessage: () => '' },
+      runtime: {
+        lastError: null,
+        onInstalled: { addListener() {} },
+        onStartup: { addListener() {} },
+        onMessage: { addListener() {} }
+      },
+      storage: {}
+    },
+    R2AIServiceWorkerTest: {}
+  };
+  context.chrome.storage.local = makeArea(localStore);
+  context.chrome.storage.session = makeArea(sessionStore, { failOnSet: 'QUOTA_BYTES quota exceeded' });
+  context.localStore = localStore;
+  context.sessionStore = sessionStore;
+  return context;
+}
+
+async function loadServiceWorker(ctx) {
+  const source = await readFile(new URL('../src/service_worker.js', import.meta.url), 'utf8');
+  const parserSource = await readFile(new URL('../src/redditParser.js', import.meta.url), 'utf8');
+  vm.runInNewContext(parserSource, ctx, { filename: 'redditParser.js' });
+  vm.runInNewContext(source, ctx, { filename: 'service_worker.js' });
+  return ctx.R2AIServiceWorkerTest;
+}
+
+// setStorage rejects when chrome.runtime.lastError is set.
+{
+  const ctx = createContext();
+  const api = await loadServiceWorker(ctx);
+  await assert.rejects(
+    () => api.setStorage(ctx.chrome.storage.session, { foo: 'bar' }),
+    /QUOTA_BYTES quota exceeded/
+  );
+}
+
+// setStorage resolves normally when there is no lastError.
+{
+  const ctx = createContext();
+  const api = await loadServiceWorker(ctx);
+  await api.setStorage(ctx.chrome.storage.local, { foo: 'bar' });
+  assert.equal(ctx.localStore.get('foo'), 'bar');
+  const read = await api.getStorage(ctx.chrome.storage.local, 'foo');
+  assert.equal(read.foo, 'bar');
+}
+
+// savePreviewData falls back to chrome.storage.local when the session write fails.
+{
+  const ctx = createContext();
+  const api = await loadServiceWorker(ctx);
+  const data = { post: { title: 'hello' }, comments: [] };
+  const payload = await api.savePreviewData(data, { dataStorageOption: 'session' });
+  assert.ok(payload.handoffId);
+  assert.equal(ctx.sessionStore.size, 0, 'session write should have failed');
+  const stored = [...ctx.localStore.values()].find(v => v && v.data);
+  assert.ok(stored, 'preview payload should be present in local storage');
+  assert.deepEqual(stored.data, data);
+}
+
+console.log('Service worker storage error tests passed!');

--- a/tests/subredditTemplates.test.mjs
+++ b/tests/subredditTemplates.test.mjs
@@ -56,6 +56,8 @@ function createContext() {
 
 async function loadServiceWorker(context) {
   const source = await readFile(new URL('../src/service_worker.js', import.meta.url), 'utf8');
+  const parserSource = await readFile(new URL('../src/redditParser.js', import.meta.url), 'utf8');
+  vm.runInNewContext(parserSource, context, { filename: 'redditParser.js' });
   vm.runInNewContext(source, context, { filename: 'service_worker.js' });
   return context.R2AIServiceWorkerTest;
 }


### PR DESCRIPTION
## Description

A full audit of the extension, followed by fixes for what it turned up and two new features. Bumps the version to **1.4.0** (minor, not patch — this adds direct API mode and a second browser target).

No linked issue; this started as an open-ended "suggest ways to improve this addon" review.

The audit found several subsystems that had never actually worked:

- **`npm run lint` was checking nothing.** When sources moved into `src/` in a639a47, the eslint config kept pointing at root-level `*.js`. CI had been passing vacuously ever since. (The code turned out to be clean once actually linted.)
- **The remote selector updater had never delivered an update.** It fetched a `selectors.json` that didn't exist in the repo, so every daily sync silently 404'd — leaving the extension's only defense against AI-site DOM changes inert.
- **The context budget was never enforced.** `trimCommentsToCharBudget` was exported but never called, so per-preset `maxChars` (24k/70k/160k) did nothing and presets trimmed by comment count only.
- **Image-paste success detection was inverted.** `dispatchEvent` returning `false` means a listener called `preventDefault()` — which is exactly what ChatGPT and Claude do when they *successfully* consume a pasted image. Successes were logged as failures and vice versa; the unit test missed it because it mocked `dispatchEvent` to always return `true`.

Plus a set of real bugs: prompts landing in the wrong text box on Claude/Gemini, nested replies flattening on single-thread scrapes, silent storage-quota failures, a login-check that false-positived on logged-in pages, users named Talbot/Abbot classified as bots, and a settings import that double-bound every event listener.

**Notable for non-English users:** progress tracking, the comment badge, the completion toast and the panel auto-hide were all driven by matching English substrings ("batch", "sent") against text that had been localized — so none of it fired in any of the other seven languages. State now carries structured `phase`/`status`/`batch` fields.

### New features

- **Direct API mode** — bring your own Anthropic / OpenAI / Gemini key and get the response rendered in the preview page, bypassing DOM auto-paste entirely (which is the source of most of the fragility above). Keys live in `storage.local` only, never sync, only ever in request headers, and are excluded from settings export; tests fail the build if any of that regresses. Model names are free-text so new model IDs work without an extension update.
- **Firefox build** — `npm run package:extension` now emits both zips from the single source manifest via a transform. The only source change needed was guarding `importScripts`; every `chrome.*` API in use is supported by Firefox 121+ with callback style, so no polyfill and no rewrite.
- **`Alt+Shift+S` shortcut** and a right-click "Scrape this thread" entry (works on pages and on links).

### Other

- Dropped the `tabs` permission after auditing every call site — smaller install warning, one less store-review flag.
- Settings import now validates against a shared key/type allowlist (previously a shared settings file could plant `customOrigins`/`customSelectors`, which control where scraped content gets sent).
- The 1MB tokenizer table no longer loads in the service worker, popup, or every Reddit/AI tab — only lazily, on the preview page.
- Extracted `src/redditParser.js`, removing ~240 lines of duplicated parsing that had drifted into two different behaviors between the content script and the worker.
- Test runner switched to `node --test` auto-discovery; the old hand-maintained `&&` chain had already lost track of one existing file.
- Test suite: **24 → 34 files.**

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update — README updated in this PR

**Permissions changed** (relevant to the store listing): `tabs` removed; `contextMenus` added; `api.anthropic.com`, `api.openai.com`, `generativelanguage.googleapis.com` added as host permissions for direct API mode. Users will see a new permission prompt on update.

## How Has This Been Tested?

Automated, via `npm run check` (JSON validation → lint → 34 test files → package both zips → validate both):

- [x] Full check green at the tip of the branch
- [x] New tests for the char-budget trimmer, storage error paths, selector-payload sanitization, corrected image-paste semantics, scrape handoff across a cold-started worker, paste-target scoring, popup accessibility, provider request-building/response-parsing (mocked fetch), API-key safety, and the generated Firefox manifest
- [x] A drift test parses the real `importScripts` argument list out of `service_worker.js` and asserts it matches the Firefox background script list, so the two can't diverge silently

**Not yet done — needs a human:**

- [ ] Chrome: click through popup → preview → send, both the auto-paste and direct-API paths
- [ ] Firefox: has never been run in an actual Firefox. Load via `about:debugging` and check event-page idle/resume, user-granted host permissions, and auto-paste on the AI sites. `strict_min_version` is set conservatively at 121 and unverified live.
- [ ] Direct API mode against real keys for all three providers

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Note for the reviewer

The commits are **split by theme, but the split is approximate** — `service_worker.js` was touched by all seven workstreams, the locale files by three, and `manifest.json` / `preview.js` / `options.js` by three or four each. Git can only put a whole file in one commit, so each file went to the theme that dominates its diff, and every commit message spells out what else it carries. Read the messages, not just the titles.

Only the tip is verified; the intermediate commits won't individually pass tests, so **this branch is not bisectable**. Squash-merging is the right call.

The first commit (`b200efc`) is pre-existing in-flight UI work that was already uncommitted in the working tree before any of this — separated out where possible so it isn't attributed to the audit, though the parts in `popup.css` / `preview.css` / `options.css` couldn't be isolated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)